### PR TITLE
Harden CSS sinks, deduplicate chart helpers, expand test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,15 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          coverage: none
+          coverage: pcov
 
       - name: Install dependencies
         run: composer install --no-interaction --prefer-dist
 
-      - name: Run checks
-        run: composer check
+      - name: Lint and code style
+        run: |
+          composer lint
+          composer cs
+
+      - name: Tests with coverage
+        run: vendor/bin/phpunit --coverage-text --coverage-filter=src

--- a/src/Charts/AbstractChart.php
+++ b/src/Charts/AbstractChart.php
@@ -48,4 +48,15 @@ abstract class AbstractChart implements \Stringable
     {
         return $this->render();
     }
+
+    protected function formatNumber(float $value): string
+    {
+        if (abs($value) >= 1000) {
+            return number_format($value, 0, '.', ',');
+        }
+        if (floor($value) === $value) {
+            return (string) (int) $value;
+        }
+        return rtrim(rtrim(number_format($value, 2, '.', ''), '0'), '.');
+    }
 }

--- a/src/Charts/BarChart.php
+++ b/src/Charts/BarChart.php
@@ -306,15 +306,4 @@ class BarChart extends AbstractChart
 
         return $wrapper->render();
     }
-
-    protected function formatNumber(float $value): string
-    {
-        if (abs($value) >= 1000) {
-            return number_format($value, 0, '.', ',');
-        }
-        if (floor($value) === $value) {
-            return (string) (int) $value;
-        }
-        return rtrim(rtrim(number_format($value, 2, '.', ''), '0'), '.');
-    }
 }

--- a/src/Charts/LineChart.php
+++ b/src/Charts/LineChart.php
@@ -278,17 +278,6 @@ class LineChart extends AbstractChart
         }
     }
 
-    protected function formatNumber(float $value): string
-    {
-        if (abs($value) >= 1000) {
-            return number_format($value, 0, '.', ',');
-        }
-        if (floor($value) === $value) {
-            return (string) (int) $value;
-        }
-        return rtrim(rtrim(number_format($value, 2, '.', ''), '0'), '.');
-    }
-
     protected function renderEmpty(): string
     {
         $viewport = new Viewport();

--- a/src/Charts/PieChart.php
+++ b/src/Charts/PieChart.php
@@ -7,6 +7,7 @@ namespace Noeka\Svgraph\Charts;
 use Noeka\Svgraph\Data\Slice;
 use Noeka\Svgraph\Geometry\Path;
 use Noeka\Svgraph\Geometry\Viewport;
+use Noeka\Svgraph\Svg\Css;
 use Noeka\Svgraph\Svg\Label;
 use Noeka\Svgraph\Svg\Tag;
 use Noeka\Svgraph\Svg\Wrapper;
@@ -155,10 +156,11 @@ class PieChart extends AbstractChart
             $left = $col * $colWidth;
             $top = $legendTopPercent + $row * 6.0;
             $color = $slice->color ?? $this->theme->colorAt($i);
+            $swatchColor = Css::color($color) ?? 'currentColor';
 
             $swatch = '<span style="display:inline-block;width:0.5em;height:0.5em;'
                 . 'border-radius:0.125em;margin-right:0.4em;vertical-align:middle;'
-                . 'background:' . Tag::escapeAttr($color) . ';"></span>';
+                . 'background:' . $swatchColor . ';"></span>';
             $text = Tag::escapeText($slice->label);
             $wrapper->label(new Label(
                 text: $swatch . $text,

--- a/src/Charts/SparklineChart.php
+++ b/src/Charts/SparklineChart.php
@@ -18,12 +18,4 @@ final class SparklineChart extends LineChart
         $this->fillEnabled = true;
         $this->fillOpacity = 0.15;
     }
-
-    public function render(): string
-    {
-        $this->showAxes = false;
-        $this->showGrid = false;
-        $this->showPoints = false;
-        return parent::render();
-    }
 }

--- a/src/Data/Series.php
+++ b/src/Data/Series.php
@@ -25,6 +25,10 @@ final readonly class Series implements \Countable
      * - ['Mon' => 10, 'Tue' => 24]         → label => value map
      * - [Point, Point]                     → already Points
      *
+     * Non-finite values (NaN, ±Infinity) are silently dropped — they would
+     * otherwise propagate through Scale calculations and produce a chart
+     * full of zeros.
+     *
      * @param iterable<mixed> $input
      */
     public static function from(iterable $input): self
@@ -32,19 +36,25 @@ final readonly class Series implements \Countable
         $points = [];
         foreach ($input as $key => $value) {
             if ($value instanceof Point) {
-                $points[] = $value;
+                if (is_finite($value->value)) {
+                    $points[] = $value;
+                }
                 continue;
             }
             if (is_array($value) && count($value) === 2) {
                 [$label, $val] = array_values($value);
-                $points[] = new Point((float) $val, $label === null ? null : (string) $label);
+                $val = (float) $val;
+                if (!is_finite($val)) {
+                    continue;
+                }
+                $points[] = new Point($val, $label === null ? null : (string) $label);
                 continue;
             }
-            if (is_int($key)) {
-                $points[] = new Point((float) $value);
-            } else {
-                $points[] = new Point((float) $value, (string) $key);
+            $val = (float) $value;
+            if (!is_finite($val)) {
+                continue;
             }
+            $points[] = new Point($val, is_int($key) ? null : (string) $key);
         }
         return new self($points);
     }

--- a/src/Data/Slice.php
+++ b/src/Data/Slice.php
@@ -19,6 +19,11 @@ final readonly class Slice
      * - [['Stripe', 1240], ['PayPal', 432, '#10b981']]
      * - [Slice, Slice]
      *
+     * Non-finite values (NaN, ±Infinity) are silently dropped. Tuple inputs
+     * must have at least [label, value]; shorter arrays throw to surface
+     * the mistake at the point of construction rather than producing an
+     * empty-labelled zero slice.
+     *
      * @param iterable<mixed> $input
      * @return list<self>
      */
@@ -27,17 +32,31 @@ final readonly class Slice
         $slices = [];
         foreach ($input as $key => $value) {
             if ($value instanceof self) {
-                $slices[] = $value;
+                if (is_finite($value->value)) {
+                    $slices[] = $value;
+                }
                 continue;
             }
             if (is_array($value)) {
+                if (count($value) < 2) {
+                    throw new \InvalidArgumentException(
+                        'Slice tuple must contain at least [label, value]; got ' . count($value) . ' element(s).',
+                    );
+                }
                 $label = (string) ($value[0] ?? '');
                 $val = (float) ($value[1] ?? 0);
+                if (!is_finite($val)) {
+                    continue;
+                }
                 $color = isset($value[2]) ? (string) $value[2] : null;
                 $slices[] = new self($label, $val, $color);
                 continue;
             }
-            $slices[] = new self((string) $key, (float) $value);
+            $val = (float) $value;
+            if (!is_finite($val)) {
+                continue;
+            }
+            $slices[] = new self((string) $key, $val);
         }
         return $slices;
     }

--- a/src/Geometry/Scale.php
+++ b/src/Geometry/Scale.php
@@ -19,6 +19,11 @@ final readonly class Scale
         public bool $invert = false,
     ) {}
 
+    /**
+     * Build a scale, widening a degenerate (zero-width) domain by 1.0 so
+     * `map()` doesn't divide by zero. Callers that want explicit control
+     * should construct the scale directly.
+     */
     public static function linear(float $domainMin, float $domainMax, float $rangeStart, float $rangeEnd, bool $invert = false): self
     {
         if ($domainMin === $domainMax) {

--- a/src/Geometry/Viewport.php
+++ b/src/Geometry/Viewport.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Noeka\Svgraph\Geometry;
 
+use Noeka\Svgraph\Svg\Tag;
+
 /**
  * The logical SVG viewport. We always use a fixed 100x100 box because the
  * outer wrapper stretches the SVG with preserveAspectRatio="none". Padding
@@ -57,10 +59,6 @@ final readonly class Viewport
 
     public function viewBox(): string
     {
-        return sprintf(
-            '0 0 %s %s',
-            rtrim(rtrim(number_format($this->width, 2, '.', ''), '0'), '.'),
-            rtrim(rtrim(number_format($this->height, 2, '.', ''), '0'), '.'),
-        );
+        return '0 0 ' . Tag::formatFloat($this->width) . ' ' . Tag::formatFloat($this->height);
     }
 }

--- a/src/Svg/Css.php
+++ b/src/Svg/Css.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noeka\Svgraph\Svg;
+
+/**
+ * Allowlist sanitizers for values interpolated into a CSS context inside a
+ * `style="..."` attribute. Tag::escapeAttr stops attribute breakout, but the
+ * contents of the attribute are still parsed as a CSS declaration list — so
+ * a value like `red;background:url(x)` would inject an extra rule. These
+ * helpers accept a tight whitelist and return null for anything else, so
+ * callers can fall back to a safe default.
+ */
+final class Css
+{
+    private const COLOR = '/\A(?:#[0-9a-f]{3,8}|rgba?\([0-9.,\s%\-]{1,40}\)|hsla?\([0-9.,\s%\-]{1,40}\)|[a-z]{3,20})\z/i';
+    private const LENGTH = '/\A[0-9]+(?:\.[0-9]+)?(?:px|em|rem|%|pt|vh|vw|ex|ch)?\z/';
+    private const FONT_FAMILY = '/\A[A-Za-z0-9 ,\-\'"]{1,80}\z/';
+
+    public static function color(?string $value): ?string
+    {
+        return $value !== null && preg_match(self::COLOR, $value) === 1 ? $value : null;
+    }
+
+    public static function length(?string $value): ?string
+    {
+        return $value !== null && preg_match(self::LENGTH, $value) === 1 ? $value : null;
+    }
+
+    public static function fontFamily(?string $value): ?string
+    {
+        return $value !== null && preg_match(self::FONT_FAMILY, $value) === 1 ? $value : null;
+    }
+}

--- a/src/Svg/Label.php
+++ b/src/Svg/Label.php
@@ -54,8 +54,9 @@ final readonly class Label
             $rules[] = "transform:translate({$tx},{$ty})";
         }
         $rules[] = 'white-space:nowrap';
-        if ($this->color !== null) {
-            $rules[] = 'color:' . $this->color;
+        $color = Css::color($this->color);
+        if ($color !== null) {
+            $rules[] = 'color:' . $color;
         }
 
         $span = Tag::make('span', ['style' => implode(';', $rules)]);

--- a/src/Svg/Wrapper.php
+++ b/src/Svg/Wrapper.php
@@ -87,11 +87,14 @@ final class Wrapper
         $div->append($svg);
 
         if ($this->labels !== []) {
+            $fontFamily = Css::fontFamily($this->theme->fontFamily) ?? 'inherit';
+            $fontSize = Css::length($this->theme->fontSize) ?? '0.75rem';
+            $textColor = Css::color($this->theme->textColor) ?? 'currentColor';
             $labelStyle = sprintf(
                 'position:absolute;inset:0;pointer-events:none;font-family:%s;font-size:%s;color:%s;line-height:1;',
-                $this->theme->fontFamily,
-                $this->theme->fontSize,
-                $this->theme->textColor,
+                $fontFamily,
+                $fontSize,
+                $textColor,
             );
             $labelTag = Tag::make('div', [
                 'class' => 'svgraph__labels',

--- a/tests/Charts/ChartRenderingTest.php
+++ b/tests/Charts/ChartRenderingTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Noeka\Svgraph\Tests\Charts;
 
 use Noeka\Svgraph\Chart;
+use Noeka\Svgraph\Theme;
 use PHPUnit\Framework\TestCase;
 
 final class ChartRenderingTest extends TestCase
@@ -20,6 +21,48 @@ final class ChartRenderingTest extends TestCase
         self::assertStringContainsString('padding-bottom:', $svg);
     }
 
+    public function test_line_smooth_uses_cubic_beziers(): void
+    {
+        $straight = Chart::line([10, 50, 30, 70])->render();
+        $smooth = Chart::line([10, 50, 30, 70])->smooth()->render();
+
+        self::assertDoesNotMatchRegularExpression('/d="M[^"]*C/', $straight);
+        self::assertMatchesRegularExpression('/d="M[^"]*C/', $smooth);
+    }
+
+    public function test_line_fill_below_emits_area_path(): void
+    {
+        $svg = Chart::line([10, 50, 30, 70])->fillBelow('#8b5cf6', 0.25)->render();
+
+        self::assertSame(2, substr_count($svg, '<path '));
+        self::assertStringContainsString('fill-opacity="0.25"', $svg);
+        self::assertStringContainsString('fill="#8b5cf6"', $svg);
+    }
+
+    public function test_line_points_emit_ellipse_markers(): void
+    {
+        $svg = Chart::line([10, 50, 30, 70])->points()->render();
+
+        self::assertSame(4, substr_count($svg, '<ellipse '));
+    }
+
+    public function test_line_axes_emit_axis_lines_and_tick_labels(): void
+    {
+        $svg = Chart::line([['Mon', 10], ['Tue', 24]])->axes()->render();
+
+        self::assertSame(2, substr_count($svg, '<line '));
+        self::assertStringContainsString('svgraph__labels', $svg);
+        self::assertStringContainsString('Mon', $svg);
+        self::assertStringContainsString('Tue', $svg);
+    }
+
+    public function test_line_grid_emits_horizontal_lines(): void
+    {
+        $svg = Chart::line([10, 50, 30, 70])->grid()->ticks(4)->render();
+
+        self::assertGreaterThanOrEqual(2, substr_count($svg, '<line '));
+    }
+
     public function test_sparkline_renders_with_fill(): void
     {
         $svg = Chart::sparkline([10, 12, 8, 18])->render();
@@ -28,12 +71,49 @@ final class ChartRenderingTest extends TestCase
         self::assertStringContainsString('fill-opacity="0.15"', $svg);
     }
 
+    public function test_sparkline_axes_opt_in_renders_axis_lines(): void
+    {
+        // Regression: previously SparklineChart::render() reset showAxes=false,
+        // silently dropping any ->axes() call.
+        $svg = Chart::sparkline([['Mon', 10], ['Tue', 24], ['Wed', 18]])->axes()->render();
+
+        self::assertSame(2, substr_count($svg, '<line '));
+        self::assertStringContainsString('svgraph__labels', $svg);
+    }
+
     public function test_bar_chart_renders_rects(): void
     {
         $svg = Chart::bar(['Jan' => 10, 'Feb' => 20, 'Mar' => 5])->render();
 
         self::assertStringContainsString('svgraph--bar', $svg);
         self::assertStringContainsString('<rect', $svg);
+        self::assertSame(3, substr_count($svg, '<rect '));
+    }
+
+    public function test_bar_rounded_sets_corner_radius(): void
+    {
+        $svg = Chart::bar(['Jan' => 10, 'Feb' => 20])->rounded(2.5)->render();
+
+        self::assertStringContainsString('rx="2.5"', $svg);
+        self::assertStringContainsString('ry="2.5"', $svg);
+    }
+
+    public function test_bar_rainbow_uses_palette(): void
+    {
+        $svg = Chart::bar(['A' => 1, 'B' => 1, 'C' => 1])->rainbow()->render();
+
+        // Default palette starts with #3b82f6, #10b981, #f59e0b.
+        self::assertStringContainsString('fill="#3b82f6"', $svg);
+        self::assertStringContainsString('fill="#10b981"', $svg);
+        self::assertStringContainsString('fill="#f59e0b"', $svg);
+    }
+
+    public function test_bar_handles_negative_values(): void
+    {
+        // Baseline at zero: positive bars hang from baseline downward,
+        // negative bars extend upward (i.e. y > baseline). Renders without throwing.
+        $svg = Chart::bar(['A' => 5, 'B' => -3, 'C' => 7])->render();
+
         self::assertSame(3, substr_count($svg, '<rect '));
     }
 
@@ -55,6 +135,23 @@ final class ChartRenderingTest extends TestCase
         self::assertSame(3, substr_count($svg, '<path '));
     }
 
+    public function test_pie_start_angle_rotates_slices(): void
+    {
+        $a = Chart::pie(['A' => 1, 'B' => 1])->render();
+        $b = Chart::pie(['A' => 1, 'B' => 1])->startAngle(90)->render();
+
+        self::assertNotSame($a, $b);
+    }
+
+    public function test_pie_gap_separates_slices(): void
+    {
+        $tight = Chart::pie(['A' => 1, 'B' => 1, 'C' => 1])->render();
+        $padded = Chart::pie(['A' => 1, 'B' => 1, 'C' => 1])->gap(5)->render();
+
+        self::assertNotSame($tight, $padded);
+        self::assertSame(3, substr_count($padded, '<path '));
+    }
+
     public function test_donut_chart_uses_donut_variant(): void
     {
         $svg = Chart::donut(['A' => 1, 'B' => 1])->thickness(0.5)->render();
@@ -67,8 +164,36 @@ final class ChartRenderingTest extends TestCase
         $svg = Chart::pie(['Stripe' => 100, 'PayPal' => 50])->legend()->render();
 
         self::assertStringContainsString('svgraph__labels', $svg);
-        self::assertStringContainsString('Stripe', $svg);
-        self::assertStringContainsString('PayPal', $svg);
+        // Anchor labels inside the legend container so a future change that
+        // moves them elsewhere doesn't pass trivially.
+        self::assertMatchesRegularExpression(
+            '/svgraph__labels.*Stripe.*PayPal/s',
+            $svg,
+        );
+    }
+
+    public function test_pie_legend_color_with_css_injection_is_sanitized(): void
+    {
+        // Regression: Slice colors flow into the legend swatch's `style` attribute,
+        // which is parsed as CSS. Tag::escapeAttr alone doesn't prevent injecting
+        // extra CSS rules (`;`, `:`, parens aren't HTML-special), so the swatch
+        // background must be allowlist-sanitized via Css::color.
+        $svg = Chart::pie([
+            ['Stripe', 100, 'red;background:url(http://evil.example/x)'],
+        ])->legend()->render();
+
+        // Assert the swatch span style is clean and contains the safe fallback.
+        // (The malicious string still appears inside an SVG `fill=` attribute,
+        // which is harmless: escapeAttr prevents attribute breakout and SVG
+        // ignores invalid paint values.)
+        self::assertMatchesRegularExpression(
+            '/<span style="display:inline-block[^"]*background:currentColor[^"]*"/',
+            $svg,
+        );
+        self::assertDoesNotMatchRegularExpression(
+            '/<span style="display:inline-block[^"]*url\(/',
+            $svg,
+        );
     }
 
     public function test_progress_clamps_to_target(): void
@@ -77,12 +202,49 @@ final class ChartRenderingTest extends TestCase
 
         self::assertStringContainsString('svgraph--progress', $svg);
         self::assertSame(2, substr_count($svg, '<rect '));
+        // Both rects must be width="100": the track (full) and the clamped fill.
+        // A naive (un-clamped) implementation would emit width="150" for the fill.
+        self::assertStringNotContainsString('width="150"', $svg);
+        self::assertSame(2, substr_count($svg, 'width="100"'));
     }
 
-    public function test_progress_zero_target_does_not_explode(): void
+    public function test_progress_zero_target_emits_only_track(): void
     {
         $svg = Chart::progress(50, 0)->render();
+
         self::assertStringContainsString('svgraph--progress', $svg);
+        // Only the track rect; no fill rect when fraction is zero.
+        self::assertSame(1, substr_count($svg, '<rect '));
+    }
+
+    public function test_progress_show_value_emits_percentage_label(): void
+    {
+        $svg = Chart::progress(75, 100)->showValue()->render();
+
+        self::assertStringContainsString('svgraph__labels', $svg);
+        self::assertStringContainsString('75%', $svg);
+    }
+
+    public function test_theme_dark_changes_label_text_color(): void
+    {
+        $svg = Chart::line([['Mon', 10], ['Tue', 24]])
+            ->axes()
+            ->theme(Theme::dark())
+            ->render();
+
+        // Dark theme textColor is #e5e7eb; default theme is #374151.
+        self::assertStringContainsString('#e5e7eb', $svg);
+    }
+
+    public function test_theme_with_palette_overrides_rainbow_bars(): void
+    {
+        $svg = Chart::bar(['A' => 1, 'B' => 1])
+            ->rainbow()
+            ->theme(Theme::default()->withPalette('#123456', '#abcdef'))
+            ->render();
+
+        self::assertStringContainsString('fill="#123456"', $svg);
+        self::assertStringContainsString('fill="#abcdef"', $svg);
     }
 
     public function test_user_class_appears_on_wrapper(): void

--- a/tests/Data/SeriesTest.php
+++ b/tests/Data/SeriesTest.php
@@ -67,4 +67,28 @@ final class SeriesTest extends TestCase
     {
         self::assertFalse(Series::from([10, 20, 30])->hasLabels());
     }
+
+    public function test_from_drops_non_finite_values(): void
+    {
+        $series = Series::from([10, NAN, 20, INF, -INF, 30]);
+        self::assertSame([10.0, 20.0, 30.0], $series->values());
+    }
+
+    public function test_from_drops_non_finite_in_tuples_and_assoc(): void
+    {
+        $tuples = Series::from([['A', 1], ['B', NAN], ['C', 3]]);
+        self::assertSame([1.0, 3.0], $tuples->values());
+        self::assertSame(['A', 'C'], $tuples->labels());
+
+        $assoc = Series::from(['A' => 1, 'B' => INF, 'C' => 3]);
+        self::assertSame([1.0, 3.0], $assoc->values());
+        self::assertSame(['A', 'C'], $assoc->labels());
+    }
+
+    public function test_from_drops_non_finite_point_objects(): void
+    {
+        $series = Series::from([new Point(5.0, 'A'), new Point(NAN, 'B'), new Point(7.0, 'C')]);
+        self::assertSame([5.0, 7.0], $series->values());
+        self::assertSame(['A', 'C'], $series->labels());
+    }
 }

--- a/tests/Data/SliceTest.php
+++ b/tests/Data/SliceTest.php
@@ -37,4 +37,43 @@ final class SliceTest extends TestCase
         self::assertSame($s1, $result[0]);
         self::assertSame($s2, $result[1]);
     }
+
+    public function test_list_from_drops_non_finite_values(): void
+    {
+        $slices = Slice::listFrom([
+            ['A', 10],
+            ['B', NAN],
+            ['C', INF],
+            ['D', 40],
+        ]);
+        self::assertCount(2, $slices);
+        self::assertSame('A', $slices[0]->label);
+        self::assertSame('D', $slices[1]->label);
+    }
+
+    public function test_list_from_drops_non_finite_assoc_and_objects(): void
+    {
+        $slices = Slice::listFrom([
+            'A' => 10,
+            'B' => NAN,
+            new Slice('C', INF),
+            new Slice('D', 40.0),
+        ]);
+        self::assertCount(2, $slices);
+        self::assertSame('A', $slices[0]->label);
+        self::assertSame('D', $slices[1]->label);
+    }
+
+    public function test_list_from_throws_on_short_tuple(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('at least [label, value]');
+        Slice::listFrom([['Stripe']]);
+    }
+
+    public function test_list_from_throws_on_empty_tuple(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        Slice::listFrom([[]]);
+    }
 }


### PR DESCRIPTION
Address findings from a code review of the library:

- Add Svg/Css.php allowlist sanitizers (color, length, fontFamily) and apply
  them at every place a caller-supplied string lands in a `style="..."`
  attribute: Label color, Wrapper label container (theme font/size/color),
  and PieChart legend swatch background. Tag::escapeAttr alone prevents
  attribute breakout but doesn't stop CSS-rule injection inside the
  attribute (`;`, `:`, parens aren't HTML-special), so a slice color like
  `red;background:url(...)` would otherwise inject extra rules into the
  legend swatch. Sanitized values fall back to safe defaults.
- Drop SparklineChart::render() override that silently reset
  showAxes/showGrid/showPoints on every call, making `->axes()` opt-in
  ineffective. Defaults are inherited from LineChart already.
- Pull duplicated formatNumber() up from LineChart and BarChart into
  AbstractChart.
- Use Tag::formatFloat in Viewport::viewBox() instead of a parallel
  rtrim+number_format implementation.
- Strengthen weak ChartRenderingTest assertions (progress clamp now asserts
  the fill rect width, zero-target asserts only the track is emitted, pie
  legend test anchors labels inside the legend container) and add coverage
  for previously untested rendering features: smooth, fillBelow, points,
  axes/grid integration, rounded, rainbow, negative bars, startAngle, gap,
  showValue, Theme::dark, Theme::withPalette, sparkline axes opt-in, and a
  CSS-injection regression test for legend swatches.

https://claude.ai/code/session_01KLwyJfrWVApMrDQYtLrnyj