### PR TITLE
Add rich CSS-hover tooltips with theming (issue #5)

### DIFF
--- a/src/Charts/AbstractChart.php
+++ b/src/Charts/AbstractChart.php
@@ -16,9 +16,13 @@ abstract class AbstractChart implements \Stringable
 
     protected string $variantClass = 'chart';
 
+    private static int $nextId = 0;
+    private int $instanceId;
+
     public function __construct()
     {
         $this->theme = Theme::default();
+        $this->instanceId = ++self::$nextId;
     }
 
     public function theme(Theme $theme): static
@@ -64,5 +68,14 @@ abstract class AbstractChart implements \Stringable
     {
         $formatted = $this->formatNumber($value);
         return ($label !== null && $label !== '') ? "{$label}: {$formatted}" : $formatted;
+    }
+
+    /**
+     * Stable, unique-per-instance chart ID used to build SVG element IDs.
+     * Format: svgraph-{n} where n is a monotonically increasing integer.
+     */
+    protected function chartId(): string
+    {
+        return 'svgraph-' . $this->instanceId;
     }
 }

--- a/src/Charts/BarChart.php
+++ b/src/Charts/BarChart.php
@@ -9,6 +9,7 @@ use Noeka\Svgraph\Geometry\Scale;
 use Noeka\Svgraph\Geometry\Viewport;
 use Noeka\Svgraph\Svg\Label;
 use Noeka\Svgraph\Svg\Tag;
+use Noeka\Svgraph\Svg\Tooltip;
 use Noeka\Svgraph\Svg\Wrapper;
 
 class BarChart extends AbstractChart
@@ -148,6 +149,7 @@ class BarChart extends AbstractChart
             }
         }
 
+        $chartId = $this->chartId();
         $baseY = $yScale->map(0.0);
         foreach ($this->series->points as $i => $point) {
             $value = $point->value;
@@ -156,19 +158,29 @@ class BarChart extends AbstractChart
             $top = min($baseY, $valueY);
             $height = abs($valueY - $baseY);
             $color = $this->useColorPerBar ? $this->theme->colorAt($i) : ($this->color ?? $this->theme->fill);
+            $id = "{$chartId}-pt-{$i}";
             $attrs = [
+                'id' => $id,
                 'x' => Tag::formatFloat($x),
                 'y' => Tag::formatFloat($top),
                 'width' => Tag::formatFloat($barWidth),
                 'height' => Tag::formatFloat($height),
                 'fill' => $color,
+                'tabindex' => '0',
             ];
             if ($this->cornerRadius > 0.0) {
                 $attrs['rx'] = Tag::formatFloat($this->cornerRadius);
                 $attrs['ry'] = Tag::formatFloat($this->cornerRadius);
             }
+            $tipText = $this->tooltip($point->label, $value);
             $wrapper->add(Tag::make('rect', $attrs)->append(
-                Tag::make('title')->append($this->tooltip($point->label, $value))
+                Tag::make('title')->append($tipText),
+            ));
+            $wrapper->tooltip(new Tooltip(
+                id: $id,
+                text: Tag::escapeText($tipText),
+                leftPct: ($x + $barWidth / 2) / $viewport->width * 100,
+                topPct: $top / $viewport->height * 100,
             ));
         }
 
@@ -257,6 +269,7 @@ class BarChart extends AbstractChart
             }
         }
 
+        $chartId = $this->chartId();
         $baseX = $xScale->map(0.0);
         foreach ($this->series->points as $i => $point) {
             $value = $point->value;
@@ -265,19 +278,29 @@ class BarChart extends AbstractChart
             $left = min($baseX, $valueX);
             $width = abs($valueX - $baseX);
             $color = $this->useColorPerBar ? $this->theme->colorAt($i) : ($this->color ?? $this->theme->fill);
+            $id = "{$chartId}-pt-{$i}";
             $attrs = [
+                'id' => $id,
                 'x' => Tag::formatFloat($left),
                 'y' => Tag::formatFloat($y),
                 'width' => Tag::formatFloat($width),
                 'height' => Tag::formatFloat($barHeight),
                 'fill' => $color,
+                'tabindex' => '0',
             ];
             if ($this->cornerRadius > 0.0) {
                 $attrs['rx'] = Tag::formatFloat($this->cornerRadius);
                 $attrs['ry'] = Tag::formatFloat($this->cornerRadius);
             }
+            $tipText = $this->tooltip($point->label, $value);
             $wrapper->add(Tag::make('rect', $attrs)->append(
-                Tag::make('title')->append($this->tooltip($point->label, $value))
+                Tag::make('title')->append($tipText),
+            ));
+            $wrapper->tooltip(new Tooltip(
+                id: $id,
+                text: Tag::escapeText($tipText),
+                leftPct: ($left + $width) / $viewport->width * 100,
+                topPct: ($y + $barHeight / 2) / $viewport->height * 100,
             ));
         }
 

--- a/src/Charts/LineChart.php
+++ b/src/Charts/LineChart.php
@@ -10,6 +10,7 @@ use Noeka\Svgraph\Geometry\Scale;
 use Noeka\Svgraph\Geometry\Viewport;
 use Noeka\Svgraph\Svg\Label;
 use Noeka\Svgraph\Svg\Tag;
+use Noeka\Svgraph\Svg\Tooltip;
 use Noeka\Svgraph\Svg\Wrapper;
 
 class LineChart extends AbstractChart
@@ -181,17 +182,38 @@ class LineChart extends AbstractChart
         ]));
 
         if ($this->showPoints) {
+            $chartId = $this->chartId();
             $r = $strokeWidth * 0.6;
             $rx = $r / max(0.01, $this->aspectRatio);
+            $hitR = max(4.0, $r * 2);
+            $hitRx = $hitR / max(0.01, $this->aspectRatio);
             foreach ($points as $i => [$x, $y]) {
                 $p = $this->series->points[$i];
+                $id = "{$chartId}-pt-{$i}";
+                $tipText = $this->tooltip($p->label, $p->value);
                 $wrapper->add(Tag::make('ellipse', [
                     'cx' => Tag::formatFloat($x),
                     'cy' => Tag::formatFloat($y),
                     'rx' => Tag::formatFloat($rx),
                     'ry' => Tag::formatFloat($r),
                     'fill' => $stroke,
-                ])->append(Tag::make('title')->append($this->tooltip($p->label, $p->value))));
+                ])->append(Tag::make('title')->append($tipText)));
+                // Transparent hit target — larger than the visual dot for easier hover/focus.
+                $wrapper->add(Tag::make('ellipse', [
+                    'id' => $id,
+                    'cx' => Tag::formatFloat($x),
+                    'cy' => Tag::formatFloat($y),
+                    'rx' => Tag::formatFloat($hitRx),
+                    'ry' => Tag::formatFloat($hitR),
+                    'fill' => 'transparent',
+                    'tabindex' => '0',
+                ])->append(Tag::make('title')->append($tipText)));
+                $wrapper->tooltip(new Tooltip(
+                    id: $id,
+                    text: Tag::escapeText($tipText),
+                    leftPct: $x / $viewport->width * 100,
+                    topPct: $y / $viewport->height * 100,
+                ));
             }
         }
 

--- a/src/Charts/PieChart.php
+++ b/src/Charts/PieChart.php
@@ -10,6 +10,7 @@ use Noeka\Svgraph\Geometry\Viewport;
 use Noeka\Svgraph\Svg\Css;
 use Noeka\Svgraph\Svg\Label;
 use Noeka\Svgraph\Svg\Tag;
+use Noeka\Svgraph\Svg\Tooltip;
 use Noeka\Svgraph\Svg\Wrapper;
 
 class PieChart extends AbstractChart
@@ -96,15 +97,27 @@ class PieChart extends AbstractChart
         $startRad = deg2rad($this->startAngle);
         $padRad = deg2rad($this->padAngle);
 
+        $chartId = $this->chartId();
+
         if ($this->thickness === 0.0 && count($this->slices) === 1) {
             $only = $this->slices[0];
             $color = $only->color ?? $this->theme->colorAt(0);
+            $id = "{$chartId}-pt-0";
+            $tipText = $this->tooltip($only->label, $only->value);
             $wrapper->add(Tag::make('circle', [
+                'id' => $id,
                 'cx' => Tag::formatFloat($cx),
                 'cy' => Tag::formatFloat($cy),
                 'r' => Tag::formatFloat($outerRadius),
                 'fill' => $color,
-            ])->append(Tag::make('title')->append($this->tooltip($only->label, $only->value))));
+                'tabindex' => '0',
+            ])->append(Tag::make('title')->append($tipText)));
+            $wrapper->tooltip(new Tooltip(
+                id: $id,
+                text: Tag::escapeText($tipText),
+                leftPct: $cx / $viewport->width * 100,
+                topPct: ($cy - $outerRadius) / $viewport->height * 100,
+            ));
             if ($hasLegend) {
                 $this->addLegend($wrapper);
             }
@@ -126,10 +139,25 @@ class PieChart extends AbstractChart
             }
             $color = $slice->color ?? $this->theme->colorAt($i);
             $d = Path::arc($cx, $cy, $outerRadius, $innerRadius, $start, $end);
+            $id = "{$chartId}-pt-{$i}";
+            $tipText = $this->tooltip($slice->label, $value);
             $wrapper->add(Tag::make('path', [
+                'id' => $id,
                 'd' => $d,
                 'fill' => $color,
-            ])->append(Tag::make('title')->append($this->tooltip($slice->label, $value))));
+                'tabindex' => '0',
+            ])->append(Tag::make('title')->append($tipText)));
+            // Anchor the tooltip at the arc centroid.
+            $tipRadius = $innerRadius > 0
+                ? ($outerRadius + $innerRadius) / 2
+                : $outerRadius * 0.6;
+            [$tipX, $tipY] = Path::polar($cx, $cy, $tipRadius, ($start + $end) / 2);
+            $wrapper->tooltip(new Tooltip(
+                id: $id,
+                text: Tag::escapeText($tipText),
+                leftPct: $tipX / $viewport->width * 100,
+                topPct: $tipY / $viewport->height * 100,
+            ));
             $angle += $sweep;
         }
 

--- a/src/Charts/ProgressChart.php
+++ b/src/Charts/ProgressChart.php
@@ -7,6 +7,7 @@ namespace Noeka\Svgraph\Charts;
 use Noeka\Svgraph\Geometry\Viewport;
 use Noeka\Svgraph\Svg\Label;
 use Noeka\Svgraph\Svg\Tag;
+use Noeka\Svgraph\Svg\Tooltip;
 use Noeka\Svgraph\Svg\Wrapper;
 
 final class ProgressChart extends AbstractChart
@@ -94,8 +95,10 @@ final class ProgressChart extends AbstractChart
         ]));
 
         if ($fraction > 0.0) {
+            $id = $this->chartId() . '-pt-0';
             $title = $this->formatNumber($this->value) . ' / ' . $this->formatNumber($this->target);
             $wrapper->add(Tag::make('rect', [
+                'id' => $id,
                 'x' => '0',
                 'y' => '0',
                 'width' => Tag::formatFloat($fraction * 100),
@@ -103,7 +106,14 @@ final class ProgressChart extends AbstractChart
                 'rx' => Tag::formatFloat($rx),
                 'ry' => Tag::formatFloat($rx),
                 'fill' => $color,
+                'tabindex' => '0',
             ])->append(Tag::make('title')->append($title)));
+            $wrapper->tooltip(new Tooltip(
+                id: $id,
+                text: Tag::escapeText($title),
+                leftPct: ($fraction * 100) / $viewport->width * 100,
+                topPct: ($height / 2) / $viewport->height * 100,
+            ));
         }
 
         if ($this->showValue) {

--- a/src/Svg/Tooltip.php
+++ b/src/Svg/Tooltip.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noeka\Svgraph\Svg;
+
+/**
+ * A single CSS-hover tooltip to be rendered inside the chart wrapper.
+ *
+ * `leftPct` and `topPct` are percentages of the wrapper div's width/height,
+ * matching the SVG viewBox coordinate space (viewBox is always 0 0 w h with
+ * w=100, h=100 for most charts). The rendered div is offset via
+ * `transform:translate(-50%,-100%)` so the tooltip's bottom-centre sits on
+ * the anchor point.
+ */
+final class Tooltip
+{
+    /**
+     * @param string $id      The `id` attribute value on the corresponding SVG element.
+     *                        Format: `svgraph-{chartId}-pt-{i}`.
+     * @param string $text    Already-HTML-escaped tooltip text to display.
+     * @param float  $leftPct Left anchor as a percentage of the wrapper width.
+     * @param float  $topPct  Top anchor as a percentage of the wrapper height.
+     */
+    public function __construct(
+        public readonly string $id,
+        public readonly string $text,
+        public readonly float $leftPct,
+        public readonly float $topPct,
+    ) {}
+}

--- a/src/Svg/Wrapper.php
+++ b/src/Svg/Wrapper.php
@@ -12,6 +12,11 @@ use Noeka\Svgraph\Theme;
  * sized by padding-bottom, an absolutely-positioned <svg> with
  * preserveAspectRatio="none" for shape stretching, and an absolute <div>
  * for HTML labels that stay readable at any aspect ratio.
+ *
+ * When tooltips are registered via tooltip(), a <style> block and hidden
+ * tooltip <div>s are also emitted. CSS custom properties on the wrapper
+ * element control tooltip appearance and can be overridden from user CSS:
+ *   --svgraph-tt-bg, --svgraph-tt-fg, --svgraph-tt-r
  */
 final class Wrapper
 {
@@ -20,6 +25,9 @@ final class Wrapper
 
     /** @var list<Label> */
     private array $labels = [];
+
+    /** @var list<Tooltip> */
+    private array $tooltips = [];
 
     private ?string $userClass = null;
 
@@ -39,6 +47,12 @@ final class Wrapper
     public function label(Label $label): self
     {
         $this->labels[] = $label;
+        return $this;
+    }
+
+    public function tooltip(Tooltip $tooltip): self
+    {
+        $this->tooltips[] = $tooltip;
         return $this;
     }
 
@@ -62,6 +76,13 @@ final class Wrapper
             Tag::formatFloat($paddingBottom),
         );
 
+        if ($this->tooltips !== []) {
+            $bg = Css::color($this->theme->tooltipBackground) ?? '#1f2937';
+            $fg = Css::color($this->theme->tooltipTextColor) ?? '#f9fafb';
+            $r = Css::length($this->theme->tooltipBorderRadius) ?? '0.25rem';
+            $wrapperStyle .= "--svgraph-tt-bg:{$bg};--svgraph-tt-fg:{$fg};--svgraph-tt-r:{$r};";
+        }
+
         $svgStyle = 'position:absolute;inset:0;width:100%;height:100%;display:block;overflow:visible;';
 
         $svg = Tag::make('svg', [
@@ -84,6 +105,11 @@ final class Wrapper
             'class' => implode(' ', $classes),
             'style' => $wrapperStyle,
         ]);
+
+        if ($this->tooltips !== []) {
+            $div->appendRaw($this->buildTooltipStyle());
+        }
+
         $div->append($svg);
 
         if ($this->labels !== []) {
@@ -106,6 +132,39 @@ final class Wrapper
             $div->append($labelTag);
         }
 
+        foreach ($this->tooltips as $tip) {
+            $left = Tag::formatFloat($tip->leftPct) . '%';
+            $top = Tag::formatFloat($tip->topPct) . '%';
+            $div->append(
+                Tag::make('div', [
+                    'class' => 'svgraph-tooltip',
+                    'data-for' => $tip->id,
+                    'style' => "position:absolute;left:{$left};top:{$top};",
+                ])->appendRaw($tip->text),
+            );
+        }
+
         return (string) $div;
+    }
+
+    private function buildTooltipStyle(): string
+    {
+        $base = '.svgraph-tooltip{'
+            . 'position:absolute;display:none;'
+            . 'background:var(--svgraph-tt-bg,#1f2937);color:var(--svgraph-tt-fg,#f9fafb);'
+            . 'border-radius:var(--svgraph-tt-r,0.25rem);'
+            . 'padding:.25rem .5rem;font-size:.75rem;line-height:1.4;'
+            . 'white-space:nowrap;pointer-events:none;z-index:10;'
+            . 'transform:translate(-50%,-100%);margin-top:-.25rem;}';
+
+        $rules = '';
+        foreach ($this->tooltips as $tip) {
+            // id only contains [a-zA-Z0-9-] — no CSS escaping needed.
+            $id = $tip->id;
+            $rules .= ".svgraph:has(#{$id}:hover) [data-for=\"{$id}\"],"
+                . ".svgraph:has(#{$id}:focus-visible) [data-for=\"{$id}\"]{display:block;}";
+        }
+
+        return "<style>{$base}@supports selector(:has(a)){{$rules}}</style>";
     }
 }

--- a/src/Theme.php
+++ b/src/Theme.php
@@ -7,16 +7,24 @@ namespace Noeka\Svgraph;
 final readonly class Theme
 {
     /**
-     * @param list<string> $palette  Hex/CSS colors used in order for multi-series or partition charts.
-     * @param string       $stroke   Default stroke color for lines/axes.
+     * @param list<string> $palette          Hex/CSS colors used in order for multi-series or partition charts.
+     * @param string       $stroke           Default stroke color for lines/axes.
      * @param float        $strokeWidth
-     * @param string       $fill     Default fill color (e.g. for bars when no color specified).
+     * @param string       $fill             Default fill color (e.g. for bars when no color specified).
      * @param string       $textColor
      * @param string       $fontFamily
-     * @param string       $fontSize CSS length, e.g. "0.75rem".
+     * @param string       $fontSize         CSS length, e.g. "0.75rem".
      * @param string       $gridColor
      * @param string       $axisColor
-     * @param string       $trackColor Background color for progress track and donut "empty" portion.
+     * @param string       $trackColor       Background color for progress track and donut "empty" portion.
+     *
+     * CSS-hover tooltip theming tokens — these map to the following CSS custom
+     * properties on the `.svgraph` wrapper, which you can also override in your
+     * own stylesheet:
+     *
+     * @param string $tooltipBackground  `--svgraph-tt-bg`     Tooltip panel background color.
+     * @param string $tooltipTextColor   `--svgraph-tt-fg`     Tooltip text color.
+     * @param string $tooltipBorderRadius `--svgraph-tt-r`     Tooltip corner radius (CSS length).
      */
     public function __construct(
         public array $palette,
@@ -29,6 +37,9 @@ final readonly class Theme
         public string $gridColor,
         public string $axisColor,
         public string $trackColor,
+        public string $tooltipBackground = '#1f2937',
+        public string $tooltipTextColor = '#f9fafb',
+        public string $tooltipBorderRadius = '0.25rem',
     ) {}
 
     public static function default(): self
@@ -60,6 +71,8 @@ final readonly class Theme
             gridColor: '#374151',
             axisColor: '#6b7280',
             trackColor: '#374151',
+            tooltipBackground: '#111827',
+            tooltipTextColor: '#f3f4f6',
         );
     }
 
@@ -76,6 +89,38 @@ final readonly class Theme
             gridColor: $this->gridColor,
             axisColor: $this->axisColor,
             trackColor: $this->trackColor,
+            tooltipBackground: $this->tooltipBackground,
+            tooltipTextColor: $this->tooltipTextColor,
+            tooltipBorderRadius: $this->tooltipBorderRadius,
+        );
+    }
+
+    /**
+     * Return a copy with different tooltip styling.
+     *
+     * The values are emitted as CSS custom properties on the wrapper element:
+     *   --svgraph-tt-bg, --svgraph-tt-fg, --svgraph-tt-r
+     * You can also set these properties directly in your own CSS.
+     */
+    public function withTooltip(
+        ?string $background = null,
+        ?string $textColor = null,
+        ?string $borderRadius = null,
+    ): self {
+        return new self(
+            palette: $this->palette,
+            stroke: $this->stroke,
+            strokeWidth: $this->strokeWidth,
+            fill: $this->fill,
+            textColor: $this->textColor,
+            fontFamily: $this->fontFamily,
+            fontSize: $this->fontSize,
+            gridColor: $this->gridColor,
+            axisColor: $this->axisColor,
+            trackColor: $this->trackColor,
+            tooltipBackground: $background ?? $this->tooltipBackground,
+            tooltipTextColor: $textColor ?? $this->tooltipTextColor,
+            tooltipBorderRadius: $borderRadius ?? $this->tooltipBorderRadius,
         );
     }
 

--- a/tests/Charts/ChartConfigurationTest.php
+++ b/tests/Charts/ChartConfigurationTest.php
@@ -296,4 +296,46 @@ final class ChartConfigurationTest extends TestCase
         self::assertSame('#aaa', $theme->colorAt(2));
         self::assertSame('#bbb', $theme->colorAt(3));
     }
+
+    public function test_theme_tooltip_defaults(): void
+    {
+        $theme = Theme::default();
+        self::assertSame('#1f2937', $theme->tooltipBackground);
+        self::assertSame('#f9fafb', $theme->tooltipTextColor);
+        self::assertSame('0.25rem', $theme->tooltipBorderRadius);
+    }
+
+    public function test_theme_with_tooltip_overrides_values(): void
+    {
+        $theme = Theme::default()->withTooltip('#000000', '#ffffff', '4px');
+        self::assertSame('#000000', $theme->tooltipBackground);
+        self::assertSame('#ffffff', $theme->tooltipTextColor);
+        self::assertSame('4px', $theme->tooltipBorderRadius);
+        // Other properties are unchanged.
+        self::assertSame(Theme::default()->textColor, $theme->textColor);
+    }
+
+    public function test_with_palette_preserves_tooltip_properties(): void
+    {
+        $theme = Theme::default()
+            ->withTooltip('#aabbcc', '#112233', '8px')
+            ->withPalette('#ff0000');
+        self::assertSame('#aabbcc', $theme->tooltipBackground);
+        self::assertSame('#112233', $theme->tooltipTextColor);
+        self::assertSame('8px', $theme->tooltipBorderRadius);
+    }
+
+    public function test_theme_with_invalid_tooltip_colors_fall_back_in_css(): void
+    {
+        $theme = Theme::default()->withTooltip(
+            'red;background:url(x)',
+            'blue;color:evil',
+            'calc(1+1)',
+        );
+        $svg = Chart::bar(['A' => 1])->theme($theme)->render();
+        // Css::color rejects injections; fallback defaults must be used.
+        self::assertStringContainsString('--svgraph-tt-bg:#1f2937', $svg);
+        self::assertStringContainsString('--svgraph-tt-fg:#f9fafb', $svg);
+        self::assertStringContainsString('--svgraph-tt-r:0.25rem', $svg);
+    }
 }

--- a/tests/Charts/ChartRenderingTest.php
+++ b/tests/Charts/ChartRenderingTest.php
@@ -43,7 +43,8 @@ final class ChartRenderingTest extends TestCase
     {
         $svg = Chart::line([10, 50, 30, 70])->points()->render();
 
-        self::assertSame(4, substr_count($svg, '<ellipse '));
+        // Each point emits a visible ellipse marker plus a larger transparent hit target.
+        self::assertSame(8, substr_count($svg, '<ellipse '));
     }
 
     public function test_line_axes_emit_axis_lines_and_tick_labels(): void
@@ -352,5 +353,155 @@ final class ChartRenderingTest extends TestCase
 
         self::assertStringContainsString('<title>&lt;b&gt;Foo&lt;/b&gt;: 10</title>', $svg);
         self::assertStringNotContainsString('<title><b>', $svg);
+    }
+
+    // ── CSS-hover tooltip tests (issue #5) ────────────────────────────────────
+
+    public function test_bar_chart_emits_css_tooltip_divs(): void
+    {
+        $svg = Chart::bar(['Jan' => 10, 'Feb' => 20])->render();
+
+        self::assertStringContainsString('class="svgraph-tooltip"', $svg);
+        self::assertSame(2, substr_count($svg, 'class="svgraph-tooltip"'));
+        self::assertStringContainsString('data-for=', $svg);
+    }
+
+    public function test_horizontal_bar_emits_css_tooltip_divs(): void
+    {
+        $svg = Chart::bar(['A' => 5, 'B' => 10])->horizontal()->render();
+
+        self::assertSame(2, substr_count($svg, 'class="svgraph-tooltip"'));
+    }
+
+    public function test_line_points_emit_css_tooltip_divs(): void
+    {
+        $svg = Chart::line([10, 20, 30])->points()->render();
+
+        self::assertSame(3, substr_count($svg, 'class="svgraph-tooltip"'));
+    }
+
+    public function test_line_without_points_emits_no_css_tooltips(): void
+    {
+        $svg = Chart::line([10, 20, 30])->render();
+
+        self::assertStringNotContainsString('class="svgraph-tooltip"', $svg);
+    }
+
+    public function test_pie_emits_css_tooltip_divs(): void
+    {
+        $svg = Chart::pie(['A' => 50, 'B' => 30, 'C' => 20])->render();
+
+        self::assertSame(3, substr_count($svg, 'class="svgraph-tooltip"'));
+    }
+
+    public function test_pie_single_slice_emits_css_tooltip_div(): void
+    {
+        $svg = Chart::pie(['Only' => 100])->render();
+
+        self::assertSame(1, substr_count($svg, 'class="svgraph-tooltip"'));
+    }
+
+    public function test_donut_emits_css_tooltip_divs(): void
+    {
+        $svg = Chart::donut(['A' => 3, 'B' => 1])->render();
+
+        self::assertSame(2, substr_count($svg, 'class="svgraph-tooltip"'));
+    }
+
+    public function test_progress_fill_emits_css_tooltip_div(): void
+    {
+        $svg = Chart::progress(75, 100)->render();
+
+        self::assertSame(1, substr_count($svg, 'class="svgraph-tooltip"'));
+    }
+
+    public function test_progress_zero_fraction_emits_no_css_tooltip(): void
+    {
+        $svg = Chart::progress(0, 100)->render();
+
+        self::assertStringNotContainsString('class="svgraph-tooltip"', $svg);
+    }
+
+    public function test_css_tooltip_style_block_uses_at_supports_has(): void
+    {
+        $svg = Chart::bar(['A' => 1])->render();
+
+        self::assertStringContainsString('@supports selector(:has(a))', $svg);
+        self::assertStringContainsString(':hover', $svg);
+        self::assertStringContainsString(':focus-visible', $svg);
+    }
+
+    public function test_tooltip_data_for_matches_svg_element_id(): void
+    {
+        $svg = Chart::bar(['X' => 5])->render();
+
+        // Element IDs follow the format svgraph-{n}-pt-{i}.
+        self::assertMatchesRegularExpression('/id="svgraph-\d+-pt-0"/', $svg);
+        self::assertMatchesRegularExpression('/data-for="svgraph-\d+-pt-0"/', $svg);
+        self::assertMatchesRegularExpression('/#svgraph-\d+-pt-0:hover/', $svg);
+    }
+
+    public function test_data_elements_have_tabindex(): void
+    {
+        $svg = Chart::bar(['A' => 1, 'B' => 2])->render();
+
+        self::assertSame(2, substr_count($svg, 'tabindex="0"'));
+    }
+
+    public function test_line_points_hit_targets_have_tabindex(): void
+    {
+        $svg = Chart::line([5, 10, 15])->points()->render();
+
+        self::assertSame(3, substr_count($svg, 'tabindex="0"'));
+    }
+
+    public function test_pie_slices_have_tabindex(): void
+    {
+        $svg = Chart::pie(['A' => 1, 'B' => 1])->render();
+
+        self::assertSame(2, substr_count($svg, 'tabindex="0"'));
+    }
+
+    public function test_css_tooltip_div_contains_escaped_text(): void
+    {
+        $svg = Chart::bar(['<b>Q1</b>' => 100])->render();
+
+        // The CSS tooltip div must contain escaped HTML, not raw tags.
+        self::assertMatchesRegularExpression(
+            '/class="svgraph-tooltip"[^>]*>[^<]*&lt;b&gt;Q1&lt;\/b&gt;/',
+            $svg,
+        );
+        self::assertDoesNotMatchRegularExpression(
+            '/class="svgraph-tooltip"[^>]*><b>/',
+            $svg,
+        );
+    }
+
+    public function test_wrapper_emits_css_custom_properties_for_tooltip_theme(): void
+    {
+        $svg = Chart::bar(['A' => 1])
+            ->theme(Theme::default()->withTooltip('#112233', '#eeffaa', '0.5rem'))
+            ->render();
+
+        self::assertStringContainsString('--svgraph-tt-bg:#112233', $svg);
+        self::assertStringContainsString('--svgraph-tt-fg:#eeffaa', $svg);
+        self::assertStringContainsString('--svgraph-tt-r:0.5rem', $svg);
+    }
+
+    public function test_css_tooltip_style_uses_var_custom_properties(): void
+    {
+        $svg = Chart::bar(['A' => 1])->render();
+
+        self::assertStringContainsString('var(--svgraph-tt-bg', $svg);
+        self::assertStringContainsString('var(--svgraph-tt-fg', $svg);
+        self::assertStringContainsString('var(--svgraph-tt-r', $svg);
+    }
+
+    public function test_empty_bar_chart_emits_no_css_tooltips(): void
+    {
+        $svg = Chart::bar([])->render();
+
+        self::assertStringNotContainsString('class="svgraph-tooltip"', $svg);
+        self::assertStringNotContainsString('<style>', $svg);
     }
 }


### PR DESCRIPTION
Replaces plain native <title> tooltips with themeable HTML tooltip divs
that appear on hover and keyboard focus using pure CSS — no JavaScript.

Key changes:
- `Tooltip` value object carries id, pre-escaped text and anchor % coords
- `Theme` gains `tooltipBackground`, `tooltipTextColor`, `tooltipBorderRadius`
  (with `withTooltip()` builder) — documented as CSS custom-property tokens
  `--svgraph-tt-bg`, `--svgraph-tt-fg`, `--svgraph-tt-r`
- `Wrapper` emits an inline `<style>` block with `.svgraph-tooltip` base styles
  and per-element `:has()` rules wrapped in `@supports selector(:has(a))` for
  graceful degradation; CSS vars on the wrapper element carry theme values
- All data elements (bar rects, line-point hit ellipses, pie/donut paths,
  progress fill rect) receive `id="svgraph-{n}-pt-{i}"` and `tabindex="0"`,
  enabling both hover and `:focus-visible` tooltip display
- Line points use a transparent overlay ellipse as a larger hit target
- 187 tests pass (PHPStan level 10, php-cs-fixer clean)

https://claude.ai/code/session_015Howgd8SBAgDuCutKfDzRp