### PR TITLE
Implement hover/focus highlight on data elements (issue #6)

### DIFF
--- a/src/Charts/BarChart.php
+++ b/src/Charts/BarChart.php
@@ -151,6 +151,7 @@ class BarChart extends AbstractChart
 
         $chartId = $this->chartId();
         $baseY = $yScale->map(0.0);
+        $wrapper->markHasSeriesElements();
         foreach ($this->series->points as $i => $point) {
             $value = $point->value;
             $x = $viewport->plotLeft() + $i * $slotWidth + $barOffset;
@@ -158,9 +159,11 @@ class BarChart extends AbstractChart
             $top = min($baseY, $valueY);
             $height = abs($valueY - $baseY);
             $color = $this->useColorPerBar ? $this->theme->colorAt($i) : ($this->color ?? $this->theme->fill);
+            $seriesIndex = $this->useColorPerBar ? $i : 0;
             $id = "{$chartId}-pt-{$i}";
             $attrs = [
                 'id' => $id,
+                'class' => "series-{$seriesIndex}",
                 'x' => Tag::formatFloat($x),
                 'y' => Tag::formatFloat($top),
                 'width' => Tag::formatFloat($barWidth),
@@ -271,6 +274,7 @@ class BarChart extends AbstractChart
 
         $chartId = $this->chartId();
         $baseX = $xScale->map(0.0);
+        $wrapper->markHasSeriesElements();
         foreach ($this->series->points as $i => $point) {
             $value = $point->value;
             $y = $viewport->plotTop() + $i * $slotHeight + $barOffset;
@@ -278,9 +282,11 @@ class BarChart extends AbstractChart
             $left = min($baseX, $valueX);
             $width = abs($valueX - $baseX);
             $color = $this->useColorPerBar ? $this->theme->colorAt($i) : ($this->color ?? $this->theme->fill);
+            $seriesIndex = $this->useColorPerBar ? $i : 0;
             $id = "{$chartId}-pt-{$i}";
             $attrs = [
                 'id' => $id,
+                'class' => "series-{$seriesIndex}",
                 'x' => Tag::formatFloat($left),
                 'y' => Tag::formatFloat($y),
                 'width' => Tag::formatFloat($width),

--- a/src/Charts/LineChart.php
+++ b/src/Charts/LineChart.php
@@ -187,11 +187,16 @@ class LineChart extends AbstractChart
             $rx = $r / max(0.01, $this->aspectRatio);
             $hitR = max(4.0, $r * 2);
             $hitRx = $hitR / max(0.01, $this->aspectRatio);
+            $wrapper->markHasSeriesElements();
             foreach ($points as $i => [$x, $y]) {
                 $p = $this->series->points[$i];
                 $id = "{$chartId}-pt-{$i}";
                 $tipText = $this->tooltip($p->label, $p->value);
-                $wrapper->add(Tag::make('ellipse', [
+                // Wrap visual marker + transparent hit target in a <g> so that
+                // CSS :hover/:focus-within on the group can highlight the visual
+                // ellipse even though the (larger) hit target intercepts events.
+                $group = Tag::make('g', ['class' => 'series-0']);
+                $group->append(Tag::make('ellipse', [
                     'cx' => Tag::formatFloat($x),
                     'cy' => Tag::formatFloat($y),
                     'rx' => Tag::formatFloat($rx),
@@ -199,7 +204,7 @@ class LineChart extends AbstractChart
                     'fill' => $stroke,
                 ])->append(Tag::make('title')->append($tipText)));
                 // Transparent hit target — larger than the visual dot for easier hover/focus.
-                $wrapper->add(Tag::make('ellipse', [
+                $group->append(Tag::make('ellipse', [
                     'id' => $id,
                     'cx' => Tag::formatFloat($x),
                     'cy' => Tag::formatFloat($y),
@@ -208,6 +213,7 @@ class LineChart extends AbstractChart
                     'fill' => 'transparent',
                     'tabindex' => '0',
                 ])->append(Tag::make('title')->append($tipText)));
+                $wrapper->add($group);
                 $wrapper->tooltip(new Tooltip(
                     id: $id,
                     text: Tag::escapeText($tipText),

--- a/src/Charts/PieChart.php
+++ b/src/Charts/PieChart.php
@@ -99,6 +99,8 @@ class PieChart extends AbstractChart
 
         $chartId = $this->chartId();
 
+        $wrapper->markHasSeriesElements();
+
         if ($this->thickness === 0.0 && count($this->slices) === 1) {
             $only = $this->slices[0];
             $color = $only->color ?? $this->theme->colorAt(0);
@@ -106,6 +108,7 @@ class PieChart extends AbstractChart
             $tipText = $this->tooltip($only->label, $only->value);
             $wrapper->add(Tag::make('circle', [
                 'id' => $id,
+                'class' => 'series-0',
                 'cx' => Tag::formatFloat($cx),
                 'cy' => Tag::formatFloat($cy),
                 'r' => Tag::formatFloat($outerRadius),
@@ -141,8 +144,15 @@ class PieChart extends AbstractChart
             $d = Path::arc($cx, $cy, $outerRadius, $innerRadius, $start, $end);
             $id = "{$chartId}-pt-{$i}";
             $tipText = $this->tooltip($slice->label, $value);
+            // Radial unit vector for the slice centroid — used by CSS to pop the
+            // slice outward via translate(calc(dist * --pop-x), calc(dist * --pop-y)).
+            $midAngle = ($start + $end) / 2;
+            $popX = round(sin($midAngle), 4);
+            $popY = round(-cos($midAngle), 4);
             $wrapper->add(Tag::make('path', [
                 'id' => $id,
+                'class' => "series-{$i}",
+                'style' => "--pop-x:{$popX};--pop-y:{$popY};",
                 'd' => $d,
                 'fill' => $color,
                 'tabindex' => '0',

--- a/src/Svg/Css.php
+++ b/src/Svg/Css.php
@@ -16,7 +16,9 @@ final class Css
 {
     private const COLOR = '/\A(?:#[0-9a-f]{3,8}|rgba?\([0-9.,\s%\-]{1,40}\)|hsla?\([0-9.,\s%\-]{1,40}\)|[a-z]{3,20})\z/i';
     private const LENGTH = '/\A[0-9]+(?:\.[0-9]+)?(?:px|em|rem|%|pt|vh|vw|ex|ch)?\z/';
+    private const LENGTH_WITH_UNIT = '/\A[0-9]+(?:\.[0-9]+)?(?:px|em|rem|%|pt|vh|vw|ex|ch)\z/';
     private const FONT_FAMILY = '/\A[A-Za-z0-9 ,\-\'"]{1,80}\z/';
+    private const NUMBER = '/\A[0-9]+(?:\.[0-9]+)?\z/';
 
     public static function color(?string $value): ?string
     {
@@ -31,5 +33,17 @@ final class Css
     public static function fontFamily(?string $value): ?string
     {
         return $value !== null && preg_match(self::FONT_FAMILY, $value) === 1 ? $value : null;
+    }
+
+    /** Validates a non-negative CSS `<number>` (no unit), e.g. "1.2" or "2". */
+    public static function number(?string $value): ?string
+    {
+        return $value !== null && preg_match(self::NUMBER, $value) === 1 ? $value : null;
+    }
+
+    /** Validates a CSS `<length>` that must include a unit, e.g. "3px", "0.5rem". */
+    public static function lengthWithUnit(?string $value): ?string
+    {
+        return $value !== null && preg_match(self::LENGTH_WITH_UNIT, $value) === 1 ? $value : null;
     }
 }

--- a/src/Svg/Wrapper.php
+++ b/src/Svg/Wrapper.php
@@ -31,6 +31,8 @@ final class Wrapper
 
     private ?string $userClass = null;
 
+    private bool $hasSeriesElements = false;
+
     public function __construct(
         private readonly Viewport $viewport,
         private readonly float $aspectRatio,
@@ -62,6 +64,12 @@ final class Wrapper
         return $this;
     }
 
+    public function markHasSeriesElements(): self
+    {
+        $this->hasSeriesElements = true;
+        return $this;
+    }
+
     public function render(): string
     {
         $paddingBottom = (1.0 / max($this->aspectRatio, 0.01)) * 100.0;
@@ -81,6 +89,15 @@ final class Wrapper
             $fg = Css::color($this->theme->tooltipTextColor) ?? '#f9fafb';
             $r = Css::length($this->theme->tooltipBorderRadius) ?? '0.25rem';
             $wrapperStyle .= "--svgraph-tt-bg:{$bg};--svgraph-tt-fg:{$fg};--svgraph-tt-r:{$r};";
+        }
+
+        if ($this->hasSeriesElements) {
+            $brightness = Css::number($this->theme->hoverBrightness) ?? '1.2';
+            $strokeW = Css::number($this->theme->hoverStrokeWidth) ?? '1.5';
+            $popDist = Css::lengthWithUnit($this->theme->piePopDistance) ?? '3px';
+            $wrapperStyle .= "--svgraph-hover-brightness:{$brightness};"
+                . "--svgraph-hover-stroke-width:{$strokeW};"
+                . "--svgraph-pie-pop-distance:{$popDist};";
         }
 
         $svgStyle = 'position:absolute;inset:0;width:100%;height:100%;display:block;overflow:visible;';
@@ -106,8 +123,8 @@ final class Wrapper
             'style' => $wrapperStyle,
         ]);
 
-        if ($this->tooltips !== []) {
-            $div->appendRaw($this->buildTooltipStyle());
+        if ($this->tooltips !== [] || $this->hasSeriesElements) {
+            $div->appendRaw($this->buildStyle());
         }
 
         $div->append($svg);
@@ -147,6 +164,67 @@ final class Wrapper
         return (string) $div;
     }
 
+    private function buildStyle(): string
+    {
+        $css = '';
+
+        if ($this->hasSeriesElements) {
+            $css .= $this->buildHoverStyle();
+        }
+
+        if ($this->tooltips !== []) {
+            $css .= $this->buildTooltipStyle();
+        }
+
+        return "<style>{$css}</style>";
+    }
+
+    private function buildHoverStyle(): string
+    {
+        // Bars and pie circles/paths: direct interactive elements with series class.
+        $direct = '.svgraph rect[class^="series-"]:hover,'
+            . '.svgraph rect[class^="series-"]:focus-visible{'
+            . 'filter:brightness(var(--svgraph-hover-brightness,1.2));'
+            . 'stroke:currentColor;'
+            . 'stroke-width:var(--svgraph-hover-stroke-width,1.5);'
+            . 'paint-order:stroke fill;'
+            . 'outline:none;}'
+            . '.svgraph circle[class^="series-"]:hover,'
+            . '.svgraph circle[class^="series-"]:focus-visible,'
+            . '.svgraph path[class^="series-"]:hover,'
+            . '.svgraph path[class^="series-"]:focus-visible{'
+            . 'filter:brightness(var(--svgraph-hover-brightness,1.2));'
+            . 'outline:none;}';
+
+        // Line markers: visual ellipse is first child of a <g class="series-*">.
+        // :hover fires on the group when over the (transparent) hit-target child;
+        // :focus-within fires when the hit-target child receives keyboard focus.
+        $lineMarkers = '.svgraph g[class^="series-"]:hover>ellipse:first-child,'
+            . '.svgraph g[class^="series-"]:focus-within>ellipse:first-child{'
+            . 'filter:brightness(var(--svgraph-hover-brightness,1.2));}';
+
+        // Pie/donut slice pop: per-slice --pop-x/--pop-y unit vectors are set as
+        // inline CSS custom properties by the PHP renderer.
+        $piePop = '.svgraph--pie path[class^="series-"]:hover,'
+            . '.svgraph--pie path[class^="series-"]:focus-visible,'
+            . '.svgraph--donut path[class^="series-"]:hover,'
+            . '.svgraph--donut path[class^="series-"]:focus-visible{'
+            . 'transform:translate('
+            . 'calc(var(--svgraph-pie-pop-distance,3px)*var(--pop-x,0)),'
+            . 'calc(var(--svgraph-pie-pop-distance,3px)*var(--pop-y,0))'
+            . ');}';
+
+        // Under reduced motion: suppress the translate pop but keep colour change.
+        $reducedMotion = '@media (prefers-reduced-motion:reduce){'
+            . '.svgraph--pie path[class^="series-"]:hover,'
+            . '.svgraph--pie path[class^="series-"]:focus-visible,'
+            . '.svgraph--donut path[class^="series-"]:hover,'
+            . '.svgraph--donut path[class^="series-"]:focus-visible{'
+            . 'transform:none;}}';
+
+        return $direct . $lineMarkers . $piePop . $reducedMotion;
+    }
+
     private function buildTooltipStyle(): string
     {
         $base = '.svgraph-tooltip{'
@@ -165,6 +243,6 @@ final class Wrapper
                 . ".svgraph:has(#{$id}:focus-visible) [data-for=\"{$id}\"]{display:block;}";
         }
 
-        return "<style>{$base}@supports selector(:has(a)){{$rules}}</style>";
+        return $base . '@supports selector(:has(a)){' . $rules . '}';
     }
 }

--- a/src/Theme.php
+++ b/src/Theme.php
@@ -25,6 +25,13 @@ final readonly class Theme
      * @param string $tooltipBackground  `--svgraph-tt-bg`     Tooltip panel background color.
      * @param string $tooltipTextColor   `--svgraph-tt-fg`     Tooltip text color.
      * @param string $tooltipBorderRadius `--svgraph-tt-r`     Tooltip corner radius (CSS length).
+     *
+     * Hover/focus highlight theming tokens — pure CSS, overridable via custom
+     * properties on the `.svgraph` wrapper:
+     *
+     * @param string $hoverBrightness   `--svgraph-hover-brightness`   CSS `<number>` passed to brightness(). Default 1.2.
+     * @param string $hoverStrokeWidth  `--svgraph-hover-stroke-width` SVG stroke-width added on hover. Default 1.5.
+     * @param string $piePopDistance    `--svgraph-pie-pop-distance`   CSS `<length>` (e.g. "3px") pie slices pop outward by on hover. Default "3px".
      */
     public function __construct(
         public array $palette,
@@ -40,6 +47,9 @@ final readonly class Theme
         public string $tooltipBackground = '#1f2937',
         public string $tooltipTextColor = '#f9fafb',
         public string $tooltipBorderRadius = '0.25rem',
+        public string $hoverBrightness = '1.2',
+        public string $hoverStrokeWidth = '1.5',
+        public string $piePopDistance = '3px',
     ) {}
 
     public static function default(): self
@@ -92,6 +102,9 @@ final readonly class Theme
             tooltipBackground: $this->tooltipBackground,
             tooltipTextColor: $this->tooltipTextColor,
             tooltipBorderRadius: $this->tooltipBorderRadius,
+            hoverBrightness: $this->hoverBrightness,
+            hoverStrokeWidth: $this->hoverStrokeWidth,
+            piePopDistance: $this->piePopDistance,
         );
     }
 
@@ -121,6 +134,41 @@ final readonly class Theme
             tooltipBackground: $background ?? $this->tooltipBackground,
             tooltipTextColor: $textColor ?? $this->tooltipTextColor,
             tooltipBorderRadius: $borderRadius ?? $this->tooltipBorderRadius,
+            hoverBrightness: $this->hoverBrightness,
+            hoverStrokeWidth: $this->hoverStrokeWidth,
+            piePopDistance: $this->piePopDistance,
+        );
+    }
+
+    /**
+     * Return a copy with different hover/focus highlight styling.
+     *
+     * The values are emitted as CSS custom properties on the wrapper element:
+     *   --svgraph-hover-brightness, --svgraph-hover-stroke-width, --svgraph-pie-pop-distance
+     * You can also set these properties directly in your own CSS.
+     */
+    public function withHover(
+        ?string $brightness = null,
+        ?string $strokeWidth = null,
+        ?string $piePopDistance = null,
+    ): self {
+        return new self(
+            palette: $this->palette,
+            stroke: $this->stroke,
+            strokeWidth: $this->strokeWidth,
+            fill: $this->fill,
+            textColor: $this->textColor,
+            fontFamily: $this->fontFamily,
+            fontSize: $this->fontSize,
+            gridColor: $this->gridColor,
+            axisColor: $this->axisColor,
+            trackColor: $this->trackColor,
+            tooltipBackground: $this->tooltipBackground,
+            tooltipTextColor: $this->tooltipTextColor,
+            tooltipBorderRadius: $this->tooltipBorderRadius,
+            hoverBrightness: $brightness ?? $this->hoverBrightness,
+            hoverStrokeWidth: $strokeWidth ?? $this->hoverStrokeWidth,
+            piePopDistance: $piePopDistance ?? $this->piePopDistance,
         );
     }
 

--- a/tests/Charts/ChartRenderingTest.php
+++ b/tests/Charts/ChartRenderingTest.php
@@ -504,4 +504,125 @@ final class ChartRenderingTest extends TestCase
         self::assertStringNotContainsString('class="svgraph-tooltip"', $svg);
         self::assertStringNotContainsString('<style>', $svg);
     }
+
+    // ── Hover/focus highlight tests (issue #6) ────────────────────────────────
+
+    public function test_bar_rects_have_series_class(): void
+    {
+        $svg = Chart::bar(['Jan' => 10, 'Feb' => 20, 'Mar' => 5])->render();
+
+        // All bars in a single-colour chart belong to series-0.
+        self::assertSame(3, substr_count($svg, 'class="series-0"'));
+    }
+
+    public function test_rainbow_bars_get_per_bar_series_class(): void
+    {
+        $svg = Chart::bar(['A' => 1, 'B' => 2, 'C' => 3])->rainbow()->render();
+
+        self::assertStringContainsString('class="series-0"', $svg);
+        self::assertStringContainsString('class="series-1"', $svg);
+        self::assertStringContainsString('class="series-2"', $svg);
+    }
+
+    public function test_pie_slices_have_per_slice_series_class(): void
+    {
+        $svg = Chart::pie(['A' => 50, 'B' => 30, 'C' => 20])->render();
+
+        self::assertStringContainsString('class="series-0"', $svg);
+        self::assertStringContainsString('class="series-1"', $svg);
+        self::assertStringContainsString('class="series-2"', $svg);
+    }
+
+    public function test_pie_single_slice_has_series_0_class(): void
+    {
+        $svg = Chart::pie(['Only' => 100])->render();
+
+        self::assertStringContainsString('class="series-0"', $svg);
+    }
+
+    public function test_pie_slices_have_pop_vector_inline_vars(): void
+    {
+        $svg = Chart::pie(['A' => 1, 'B' => 1])->render();
+
+        // Each slice path must carry --pop-x and --pop-y in its style attribute.
+        self::assertMatchesRegularExpression('/style="--pop-x:[^"]+--pop-y:[^"]+"/', $svg);
+    }
+
+    public function test_line_marker_groups_have_series_class(): void
+    {
+        $svg = Chart::line([10, 20, 30])->points()->render();
+
+        self::assertSame(3, substr_count($svg, 'class="series-0"'));
+        // Ellipses must be nested inside <g> elements.
+        self::assertMatchesRegularExpression('/<g class="series-0">.*<ellipse/s', $svg);
+    }
+
+    public function test_bar_chart_emits_hover_style_rules(): void
+    {
+        $svg = Chart::bar(['A' => 1])->render();
+
+        self::assertStringContainsString('brightness(var(--svgraph-hover-brightness', $svg);
+        self::assertStringContainsString('--svgraph-hover-stroke-width', $svg);
+    }
+
+    public function test_pie_chart_emits_pop_style_rules(): void
+    {
+        $svg = Chart::pie(['A' => 1, 'B' => 1])->render();
+
+        self::assertStringContainsString('--svgraph-pie-pop-distance', $svg);
+        self::assertStringContainsString('--pop-x', $svg);
+        self::assertStringContainsString('--pop-y', $svg);
+    }
+
+    public function test_hover_style_honours_prefers_reduced_motion(): void
+    {
+        $svg = Chart::pie(['A' => 1, 'B' => 1])->render();
+
+        self::assertStringContainsString('prefers-reduced-motion', $svg);
+        // The reduced-motion block must suppress the transform.
+        self::assertMatchesRegularExpression('/prefers-reduced-motion[^}]+\{[^}]*transform:none/', $svg);
+    }
+
+    public function test_hover_css_custom_properties_on_wrapper(): void
+    {
+        $svg = Chart::bar(['A' => 1])->render();
+
+        self::assertStringContainsString('--svgraph-hover-brightness:', $svg);
+        self::assertStringContainsString('--svgraph-hover-stroke-width:', $svg);
+    }
+
+    public function test_with_hover_overrides_custom_properties(): void
+    {
+        $svg = Chart::bar(['A' => 1])
+            ->theme(Theme::default()->withHover('1.5', '2', '5px'))
+            ->render();
+
+        self::assertStringContainsString('--svgraph-hover-brightness:1.5', $svg);
+        self::assertStringContainsString('--svgraph-hover-stroke-width:2', $svg);
+        self::assertStringContainsString('--svgraph-pie-pop-distance:5px', $svg);
+    }
+
+    public function test_line_without_points_emits_no_hover_style(): void
+    {
+        $svg = Chart::line([10, 20, 30])->render();
+
+        // No series elements → no <style> block at all.
+        self::assertStringNotContainsString('<style>', $svg);
+    }
+
+    public function test_horizontal_bar_rects_have_series_class(): void
+    {
+        $svg = Chart::bar(['A' => 5, 'B' => 10])->horizontal()->render();
+
+        self::assertSame(2, substr_count($svg, 'class="series-0"'));
+    }
+
+    public function test_donut_slices_have_series_class_and_pop_vars(): void
+    {
+        $svg = Chart::donut(['X' => 3, 'Y' => 1])->render();
+
+        self::assertStringContainsString('class="series-0"', $svg);
+        self::assertStringContainsString('class="series-1"', $svg);
+        self::assertStringContainsString('--pop-x:', $svg);
+    }
 }


### PR DESCRIPTION
- Add `series-{i}` CSS class to every data element (bar rects, pie/donut
  paths, line marker groups) so hover rules can target them by series.
- Emit `:hover` and `:focus-visible` rules in a combined `<style>` block:
  brightness filter for bars/circles/paths; brightness via `:focus-within`
  on the `<g>` wrapper for line markers; radial translate pop for pie/donut
  slices using per-slice `--pop-x`/`--pop-y` unit-vector inline vars.
- Pie pop is suppressed under `prefers-reduced-motion: reduce`; the
  brightness/stroke change still applies.
- Add three theme tokens to `Theme`: `hoverBrightness`, `hoverStrokeWidth`,
  `piePopDistance`, exposed as `--svgraph-hover-brightness`,
  `--svgraph-hover-stroke-width`, `--svgraph-pie-pop-distance` on the
  wrapper element and overridable from user CSS. `Theme::withHover()` lets
  callers adjust them in PHP.
- Add `Css::number()` and `Css::lengthWithUnit()` validators.
- Cover all acceptance criteria with 14 new PHPUnit tests (201 total).

https://claude.ai/code/session_01MBhBDZMX7sq3BcoJrfrodA