### PR TITLE
feat: click-through links on data elements (issue #7)

### DIFF
--- a/src/Charts/AbstractChart.php
+++ b/src/Charts/AbstractChart.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Noeka\Svgraph\Charts;
 
+use Noeka\Svgraph\Data\Link;
+use Noeka\Svgraph\Svg\Tag;
 use Noeka\Svgraph\Theme;
 
 abstract class AbstractChart implements \Stringable
@@ -77,5 +79,28 @@ abstract class AbstractChart implements \Stringable
     protected function chartId(): string
     {
         return 'svgraph-' . $this->instanceId;
+    }
+
+    /**
+     * Wrap $inner in an SVG <a> carrying $id when $link is set; otherwise
+     * attach $id and tabindex="0" directly to $inner and return it.
+     *
+     * When wrapped, the <a> is the ID/focus carrier and the inner element keeps
+     * only its visual attributes (class, fill, etc.). SVG <a> is natively
+     * keyboard-activatable via Enter — no tabindex needed.
+     */
+    protected function buildLink(?Link $link, string $id, Tag $inner): Tag
+    {
+        if ($link === null) {
+            return $inner->attr('id', $id)->attr('tabindex', '0');
+        }
+        $attrs = ['id' => $id, 'href' => $link->href, 'class' => 'svgraph-linked'];
+        if ($link->target !== null) {
+            $attrs['target'] = $link->target;
+        }
+        if ($link->rel !== '') {
+            $attrs['rel'] = $link->rel;
+        }
+        return Tag::make('a', $attrs)->append($inner);
     }
 }

--- a/src/Charts/BarChart.php
+++ b/src/Charts/BarChart.php
@@ -162,23 +162,20 @@ class BarChart extends AbstractChart
             $seriesIndex = $this->useColorPerBar ? $i : 0;
             $id = "{$chartId}-pt-{$i}";
             $attrs = [
-                'id' => $id,
                 'class' => "series-{$seriesIndex}",
                 'x' => Tag::formatFloat($x),
                 'y' => Tag::formatFloat($top),
                 'width' => Tag::formatFloat($barWidth),
                 'height' => Tag::formatFloat($height),
                 'fill' => $color,
-                'tabindex' => '0',
             ];
             if ($this->cornerRadius > 0.0) {
                 $attrs['rx'] = Tag::formatFloat($this->cornerRadius);
                 $attrs['ry'] = Tag::formatFloat($this->cornerRadius);
             }
             $tipText = $this->tooltip($point->label, $value);
-            $wrapper->add(Tag::make('rect', $attrs)->append(
-                Tag::make('title')->append($tipText),
-            ));
+            $rect = Tag::make('rect', $attrs)->append(Tag::make('title')->append($tipText));
+            $wrapper->add($this->buildLink($point->link, $id, $rect));
             $wrapper->tooltip(new Tooltip(
                 id: $id,
                 text: Tag::escapeText($tipText),
@@ -285,23 +282,20 @@ class BarChart extends AbstractChart
             $seriesIndex = $this->useColorPerBar ? $i : 0;
             $id = "{$chartId}-pt-{$i}";
             $attrs = [
-                'id' => $id,
                 'class' => "series-{$seriesIndex}",
                 'x' => Tag::formatFloat($left),
                 'y' => Tag::formatFloat($y),
                 'width' => Tag::formatFloat($width),
                 'height' => Tag::formatFloat($barHeight),
                 'fill' => $color,
-                'tabindex' => '0',
             ];
             if ($this->cornerRadius > 0.0) {
                 $attrs['rx'] = Tag::formatFloat($this->cornerRadius);
                 $attrs['ry'] = Tag::formatFloat($this->cornerRadius);
             }
             $tipText = $this->tooltip($point->label, $value);
-            $wrapper->add(Tag::make('rect', $attrs)->append(
-                Tag::make('title')->append($tipText),
-            ));
+            $rect = Tag::make('rect', $attrs)->append(Tag::make('title')->append($tipText));
+            $wrapper->add($this->buildLink($point->link, $id, $rect));
             $wrapper->tooltip(new Tooltip(
                 id: $id,
                 text: Tag::escapeText($tipText),

--- a/src/Charts/LineChart.php
+++ b/src/Charts/LineChart.php
@@ -192,6 +192,7 @@ class LineChart extends AbstractChart
                 $p = $this->series->points[$i];
                 $id = "{$chartId}-pt-{$i}";
                 $tipText = $this->tooltip($p->label, $p->value);
+                $hasLink = $p->link !== null;
                 // Wrap visual marker + transparent hit target in a <g> so that
                 // CSS :hover/:focus-within on the group can highlight the visual
                 // ellipse even though the (larger) hit target intercepts events.
@@ -204,16 +205,18 @@ class LineChart extends AbstractChart
                     'fill' => $stroke,
                 ])->append(Tag::make('title')->append($tipText)));
                 // Transparent hit target — larger than the visual dot for easier hover/focus.
-                $group->append(Tag::make('ellipse', [
-                    'id' => $id,
+                // When linked, the <a> carries id/tabindex; otherwise they live here.
+                $hitAttrs = [
+                    'id' => $hasLink ? null : $id,
                     'cx' => Tag::formatFloat($x),
                     'cy' => Tag::formatFloat($y),
                     'rx' => Tag::formatFloat($hitRx),
                     'ry' => Tag::formatFloat($hitR),
                     'fill' => 'transparent',
-                    'tabindex' => '0',
-                ])->append(Tag::make('title')->append($tipText)));
-                $wrapper->add($group);
+                    'tabindex' => $hasLink ? null : '0',
+                ];
+                $group->append(Tag::make('ellipse', $hitAttrs)->append(Tag::make('title')->append($tipText)));
+                $wrapper->add($hasLink ? $this->buildLink($p->link, $id, $group) : $group);
                 $wrapper->tooltip(new Tooltip(
                     id: $id,
                     text: Tag::escapeText($tipText),

--- a/src/Charts/PieChart.php
+++ b/src/Charts/PieChart.php
@@ -106,15 +106,14 @@ class PieChart extends AbstractChart
             $color = $only->color ?? $this->theme->colorAt(0);
             $id = "{$chartId}-pt-0";
             $tipText = $this->tooltip($only->label, $only->value);
-            $wrapper->add(Tag::make('circle', [
-                'id' => $id,
+            $circle = Tag::make('circle', [
                 'class' => 'series-0',
                 'cx' => Tag::formatFloat($cx),
                 'cy' => Tag::formatFloat($cy),
                 'r' => Tag::formatFloat($outerRadius),
                 'fill' => $color,
-                'tabindex' => '0',
-            ])->append(Tag::make('title')->append($tipText)));
+            ])->append(Tag::make('title')->append($tipText));
+            $wrapper->add($this->buildLink($only->link, $id, $circle));
             $wrapper->tooltip(new Tooltip(
                 id: $id,
                 text: Tag::escapeText($tipText),
@@ -149,14 +148,13 @@ class PieChart extends AbstractChart
             $midAngle = ($start + $end) / 2;
             $popX = round(sin($midAngle), 4);
             $popY = round(-cos($midAngle), 4);
-            $wrapper->add(Tag::make('path', [
-                'id' => $id,
+            $path = Tag::make('path', [
                 'class' => "series-{$i}",
                 'style' => "--pop-x:{$popX};--pop-y:{$popY};",
                 'd' => $d,
                 'fill' => $color,
-                'tabindex' => '0',
-            ])->append(Tag::make('title')->append($tipText)));
+            ])->append(Tag::make('title')->append($tipText));
+            $wrapper->add($this->buildLink($slice->link, $id, $path));
             // Anchor the tooltip at the arc centroid.
             $tipRadius = $innerRadius > 0
                 ? ($outerRadius + $innerRadius) / 2

--- a/src/Data/Link.php
+++ b/src/Data/Link.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noeka\Svgraph\Data;
+
+final readonly class Link
+{
+    public string $rel;
+
+    public function __construct(
+        public string $href,
+        public ?string $target = null,
+        ?string $rel = null,
+    ) {
+        if (preg_match('/^\s*javascript\s*:/i', $href)) {
+            throw new \InvalidArgumentException(
+                'javascript: URLs are not allowed in links.',
+            );
+        }
+        $this->rel = $rel ?? ($target === '_blank' ? 'noopener noreferrer' : '');
+    }
+}

--- a/src/Data/Point.php
+++ b/src/Data/Point.php
@@ -9,5 +9,6 @@ final readonly class Point
     public function __construct(
         public float $value,
         public ?string $label = null,
+        public ?Link $link = null,
     ) {}
 }

--- a/src/Data/Series.php
+++ b/src/Data/Series.php
@@ -41,13 +41,14 @@ final readonly class Series implements \Countable
                 }
                 continue;
             }
-            if (is_array($value) && count($value) === 2) {
-                [$label, $val] = array_values($value);
-                $val = self::toFloat($val);
+            if (is_array($value) && count($value) >= 2) {
+                $arr = array_values($value);
+                $val = self::toFloat($arr[1]);
                 if (!is_finite($val)) {
                     continue;
                 }
-                $points[] = new Point($val, self::toLabel($label));
+                $link = isset($arr[2]) && $arr[2] instanceof Link ? $arr[2] : null;
+                $points[] = new Point($val, self::toLabel($arr[0]), $link);
                 continue;
             }
             $val = self::toFloat($value);

--- a/src/Data/Slice.php
+++ b/src/Data/Slice.php
@@ -10,6 +10,7 @@ final readonly class Slice
         public string $label,
         public float $value,
         public ?string $color = null,
+        public ?Link $link = null,
     ) {}
 
     /**
@@ -49,7 +50,8 @@ final readonly class Slice
                     continue;
                 }
                 $color = isset($value[2]) ? self::toString($value[2]) : null;
-                $slices[] = new self($label, $val, $color);
+                $link = isset($value[3]) && $value[3] instanceof Link ? $value[3] : null;
+                $slices[] = new self($label, $val, $color, $link);
                 continue;
             }
             $val = self::toFloat($value);

--- a/src/Svg/Wrapper.php
+++ b/src/Svg/Wrapper.php
@@ -218,11 +218,38 @@ final class Wrapper
         $reducedMotion = '@media (prefers-reduced-motion:reduce){'
             . '.svgraph--pie path[class^="series-"]:hover,'
             . '.svgraph--pie path[class^="series-"]:focus-visible,'
+            . '.svgraph--pie a.svgraph-linked:focus-visible path[class^="series-"],'
             . '.svgraph--donut path[class^="series-"]:hover,'
-            . '.svgraph--donut path[class^="series-"]:focus-visible{'
+            . '.svgraph--donut path[class^="series-"]:focus-visible,'
+            . '.svgraph--donut a.svgraph-linked:focus-visible path[class^="series-"]{'
             . 'transform:none;}}';
 
-        return $direct . $lineMarkers . $piePop . $reducedMotion;
+        // Linked elements: cursor + keyboard-focus highlight rules.
+        // :hover on the inner element is already handled by the rules above
+        // (the inner rect/path/etc. is still directly under the pointer).
+        // Only :focus-visible needs extra rules because the <a> receives focus,
+        // not the inner element (which has no tabindex when wrapped).
+        $linked = '.svgraph a.svgraph-linked{cursor:pointer;}'
+            . '.svgraph a.svgraph-linked:focus-visible rect[class^="series-"]{'
+            . 'filter:brightness(var(--svgraph-hover-brightness,1.2));'
+            . 'stroke:currentColor;'
+            . 'stroke-width:var(--svgraph-hover-stroke-width,1.5);'
+            . 'paint-order:stroke fill;'
+            . 'outline:none;}'
+            . '.svgraph a.svgraph-linked:focus-visible circle[class^="series-"],'
+            . '.svgraph a.svgraph-linked:focus-visible path[class^="series-"]{'
+            . 'filter:brightness(var(--svgraph-hover-brightness,1.2));'
+            . 'outline:none;}'
+            . '.svgraph a.svgraph-linked:focus-visible g[class^="series-"]>ellipse:first-child{'
+            . 'filter:brightness(var(--svgraph-hover-brightness,1.2));}'
+            . '.svgraph--pie a.svgraph-linked:focus-visible path[class^="series-"],'
+            . '.svgraph--donut a.svgraph-linked:focus-visible path[class^="series-"]{'
+            . 'transform:translate('
+            . 'calc(var(--svgraph-pie-pop-distance,3px)*var(--pop-x,0)),'
+            . 'calc(var(--svgraph-pie-pop-distance,3px)*var(--pop-y,0))'
+            . ');}';
+
+        return $direct . $lineMarkers . $piePop . $reducedMotion . $linked;
     }
 
     private function buildTooltipStyle(): string

--- a/tests/Charts/ChartRenderingTest.php
+++ b/tests/Charts/ChartRenderingTest.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Noeka\Svgraph\Tests\Charts;
 
 use Noeka\Svgraph\Chart;
+use Noeka\Svgraph\Data\Link;
+use Noeka\Svgraph\Data\Point;
+use Noeka\Svgraph\Data\Slice;
 use Noeka\Svgraph\Theme;
 use PHPUnit\Framework\TestCase;
 
@@ -624,5 +627,134 @@ final class ChartRenderingTest extends TestCase
         self::assertStringContainsString('class="series-0"', $svg);
         self::assertStringContainsString('class="series-1"', $svg);
         self::assertStringContainsString('--pop-x:', $svg);
+    }
+
+    // ── Click-through link tests (issue #7) ──────────────────────────────────
+
+    public function test_bar_linked_point_wraps_rect_in_anchor(): void
+    {
+        $svg = Chart::bar([
+            new Point(10, 'Jan', new Link('https://example.com/jan')),
+            new Point(20, 'Feb'),
+        ])->render();
+
+        self::assertMatchesRegularExpression(
+            '/<a[^>]+href="https:\/\/example\.com\/jan"[^>]*>.*?<rect[^>]+class="series-0"/',
+            $svg,
+        );
+        self::assertStringContainsString('class="svgraph-linked"', $svg);
+        // Non-linked bar must NOT be wrapped in <a>.
+        self::assertSame(1, substr_count($svg, '<a '));
+    }
+
+    public function test_bar_linked_anchor_carries_id_and_non_linked_rect_carries_id(): void
+    {
+        $svg = Chart::bar([
+            new Point(10, 'Jan', new Link('https://example.com')),
+            new Point(20, 'Feb'),
+        ])->render();
+
+        // Linked: ID on <a>, no tabindex on rect.
+        self::assertMatchesRegularExpression('/<a[^>]+id="svgraph-\d+-pt-0"/', $svg);
+        // Non-linked: ID on rect itself.
+        self::assertMatchesRegularExpression('/<rect[^>]+id="svgraph-\d+-pt-1"/', $svg);
+    }
+
+    public function test_bar_linked_anchor_with_blank_target_gets_noopener_rel(): void
+    {
+        $svg = Chart::bar([
+            new Point(5, 'X', new Link('https://example.com', '_blank')),
+        ])->render();
+
+        self::assertStringContainsString('target="_blank"', $svg);
+        self::assertStringContainsString('rel="noopener noreferrer"', $svg);
+    }
+
+    public function test_bar_linked_anchor_explicit_rel_is_honoured(): void
+    {
+        $svg = Chart::bar([
+            new Point(5, 'X', new Link('https://example.com', '_self', 'noopener')),
+        ])->render();
+
+        self::assertStringContainsString('rel="noopener"', $svg);
+    }
+
+    public function test_bar_url_is_xml_escaped_in_href(): void
+    {
+        $svg = Chart::bar([
+            new Point(5, 'X', new Link('https://example.com/q?a=1&b=2')),
+        ])->render();
+
+        self::assertStringContainsString('href="https://example.com/q?a=1&amp;b=2"', $svg);
+    }
+
+    public function test_pie_linked_slice_wraps_path_in_anchor(): void
+    {
+        $svg = Chart::pie([
+            new Slice('Alpha', 50, null, new Link('https://example.com/alpha')),
+            new Slice('Beta', 50),
+        ])->render();
+
+        self::assertMatchesRegularExpression(
+            '/<a[^>]+href="https:\/\/example\.com\/alpha"[^>]*>.*?<path[^>]+class="series-0"/',
+            $svg,
+        );
+        self::assertSame(1, substr_count($svg, '<a '));
+    }
+
+    public function test_pie_slice_from_tuple_with_link_wraps_in_anchor(): void
+    {
+        $link = new Link('https://example.com/stripe');
+        $svg = Chart::pie([
+            ['Stripe', 80, null, $link],
+            ['PayPal', 20],
+        ])->render();
+
+        self::assertStringContainsString('href="https://example.com/stripe"', $svg);
+        self::assertSame(1, substr_count($svg, '<a '));
+    }
+
+    public function test_line_linked_point_wraps_group_in_anchor(): void
+    {
+        $svg = Chart::line([
+            new Point(10, 'Mon', new Link('https://example.com/mon')),
+            new Point(20, 'Tue'),
+        ])->points()->render();
+
+        self::assertMatchesRegularExpression(
+            '/<a[^>]+href="https:\/\/example\.com\/mon"[^>]*>.*?<g[^>]+class="series-0"/',
+            $svg,
+        );
+        self::assertSame(1, substr_count($svg, '<a '));
+    }
+
+    public function test_linked_point_from_series_tuple(): void
+    {
+        $link = new Link('https://example.com/mon');
+        $svg = Chart::bar([
+            ['Mon', 10, $link],
+            ['Tue', 20],
+        ])->render();
+
+        self::assertStringContainsString('href="https://example.com/mon"', $svg);
+        self::assertSame(1, substr_count($svg, '<a '));
+    }
+
+    public function test_linked_elements_emit_cursor_pointer_css(): void
+    {
+        $svg = Chart::bar([
+            new Point(5, 'X', new Link('https://example.com')),
+        ])->render();
+
+        self::assertStringContainsString('a.svgraph-linked{cursor:pointer;}', $svg);
+    }
+
+    public function test_linked_elements_emit_focus_visible_css(): void
+    {
+        $svg = Chart::bar([
+            new Point(5, 'X', new Link('https://example.com')),
+        ])->render();
+
+        self::assertStringContainsString('a.svgraph-linked:focus-visible', $svg);
     }
 }

--- a/tests/Data/LinkTest.php
+++ b/tests/Data/LinkTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noeka\Svgraph\Tests\Data;
+
+use Noeka\Svgraph\Data\Link;
+use PHPUnit\Framework\TestCase;
+
+final class LinkTest extends TestCase
+{
+    public function test_construct_with_href_only(): void
+    {
+        $link = new Link('https://example.com');
+        self::assertSame('https://example.com', $link->href);
+        self::assertNull($link->target);
+        self::assertSame('', $link->rel);
+    }
+
+    public function test_blank_target_defaults_rel_to_noopener_noreferrer(): void
+    {
+        $link = new Link('https://example.com', '_blank');
+        self::assertSame('_blank', $link->target);
+        self::assertSame('noopener noreferrer', $link->rel);
+    }
+
+    public function test_non_blank_target_leaves_rel_empty_by_default(): void
+    {
+        $link = new Link('https://example.com', '_self');
+        self::assertSame('', $link->rel);
+    }
+
+    public function test_explicit_rel_overrides_default(): void
+    {
+        $link = new Link('https://example.com', '_blank', 'noopener');
+        self::assertSame('noopener', $link->rel);
+    }
+
+    public function test_javascript_url_is_rejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new Link('javascript:alert(1)');
+    }
+
+    public function test_javascript_url_with_leading_spaces_is_rejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new Link('   javascript:void(0)');
+    }
+
+    public function test_javascript_url_with_mixed_case_is_rejected(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        new Link('JavaScript:alert(1)');
+    }
+
+    public function test_data_url_is_allowed(): void
+    {
+        $link = new Link('data:text/plain,hello');
+        self::assertSame('data:text/plain,hello', $link->href);
+    }
+
+    public function test_relative_url_is_allowed(): void
+    {
+        $link = new Link('/dashboard');
+        self::assertSame('/dashboard', $link->href);
+    }
+}


### PR DESCRIPTION
Adds an optional Link value object to Point and Slice so individual data
elements can carry a URL. When present, the renderer wraps the SVG element
in a native <a> — no JS required; Enter activates via keyboard.

- New Link readonly class rejects javascript: schemes and defaults
  rel="noopener noreferrer" when target="_blank".
- Point and Slice gain an optional ?Link $link parameter.
- Series::from() and Slice::listFrom() accept Link in tuple inputs.
- AbstractChart::buildLink() centralises the <a>-wrapping logic: the <a>
  carries the element ID and is the focus carrier; the inner element keeps
  class/fill/visual attrs only.
- BarChart (vertical + horizontal), LineChart (point markers), and PieChart
  (paths and single-circle) delegate to buildLink().
- Wrapper::buildHoverStyle() emits .svgraph a.svgraph-linked{cursor:pointer}
  and :focus-visible rules so keyboard-focused linked elements highlight
  consistently with mouse-hover behaviour.
- Tests cover anchor wrapping, ID placement, target/rel defaults, XML
  escaping of URLs, javascript: rejection, tuple inputs, and cursor CSS.

https://claude.ai/code/session_014MvVXVD4xFrkerHTUH5xHo