### PR TITLE
feat: CSS entrance animations with prefers-reduced-motion (issue #8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,51 @@ Chart::progress(value: 7400, target: 10000)
 
 ---
 
+## Entrance animations
+
+All chart types support opt-in CSS entrance animations via `->animate()`. Animations use pure `@keyframes` — no JavaScript required — and are always wrapped in `@media (prefers-reduced-motion: no-preference)` so users who request reduced motion always receive a static chart.
+
+```php
+// Line: the stroke draws on from left to right
+Chart::line($data)->axes()->grid()->smooth()->stroke('#3b82f6')->animate()
+
+// Bar: bars grow from the baseline
+Chart::bar(['Jan' => 120, 'Feb' => 180, 'Mar' => 90])->axes()->color('#10b981')->animate()
+
+// Horizontal bar: bars extend from the axis
+Chart::bar($data)->horizontal()->rainbow()->animate()
+
+// Pie/donut: slices sweep in using the stroke-circle technique
+Chart::pie(['Stripe' => 1240, 'PayPal' => 432, 'Bank' => 312])->legend()->animate()
+Chart::donut($data)->thickness(0.5)->animate()
+```
+
+**Animation details by chart type:**
+
+| Chart | Technique | Notes |
+|-------|-----------|-------|
+| Line / Sparkline | `stroke-dashoffset` draw-on using `pathLength="1"` | Full line draws from left to right |
+| Bar (vertical) | `scaleY` from baseline (`transform-origin` set per bar) | Negative bars grow from top |
+| Bar (horizontal) | `scaleX` from axis | Negative bars grow from right |
+| Pie / Donut | `stroke-dasharray` sweep on stroke-circles | Slices stagger by 80 ms each |
+
+Duration and easing are theme-tokenised and can be customised via `Theme::withAnimation()`:
+
+```php
+Chart::pie($data)->animate()->theme(
+    Theme::default()->withAnimation('0.4s', 'cubic-bezier(0.4,0,0.2,1)')
+)
+```
+
+| Method | Description |
+|--------|-------------|
+| `->animate(bool)` | Enable (or disable) entrance animations (default off) |
+| `Theme::withAnimation(duration, easing)` | Override `--svgraph-anim-dur` and `--svgraph-anim-ease` |
+
+The CSS custom properties `--svgraph-anim-dur` and `--svgraph-anim-ease` are emitted on the wrapper element and can also be overridden from your own stylesheet.
+
+---
+
 ## Theming
 
 All charts use `Theme::default()` out of the box. Pass a different theme or build your own:

--- a/src/Charts/AbstractChart.php
+++ b/src/Charts/AbstractChart.php
@@ -18,6 +18,8 @@ abstract class AbstractChart implements \Stringable
 
     protected string $variantClass = 'chart';
 
+    protected bool $animated = false;
+
     private static int $nextId = 0;
     private int $instanceId;
 
@@ -45,6 +47,18 @@ abstract class AbstractChart implements \Stringable
     public function cssClass(?string $class): static
     {
         $this->cssClass = $class;
+        return $this;
+    }
+
+    /**
+     * Enable CSS entrance animations. Animations are wrapped in
+     * `@media (prefers-reduced-motion: no-preference)` so users with reduced-motion
+     * preferences always see a static chart. Duration and easing are configurable
+     * via `Theme::withAnimation()`.
+     */
+    public function animate(bool $on = true): static
+    {
+        $this->animated = $on;
         return $this;
     }
 

--- a/src/Charts/BarChart.php
+++ b/src/Charts/BarChart.php
@@ -152,6 +152,9 @@ class BarChart extends AbstractChart
         $chartId = $this->chartId();
         $baseY = $yScale->map(0.0);
         $wrapper->markHasSeriesElements();
+        if ($this->animated) {
+            $wrapper->enableAnimation();
+        }
         foreach ($this->series->points as $i => $point) {
             $value = $point->value;
             $x = $viewport->plotLeft() + $i * $slotWidth + $barOffset;
@@ -172,6 +175,11 @@ class BarChart extends AbstractChart
             if ($this->cornerRadius > 0.0) {
                 $attrs['rx'] = Tag::formatFloat($this->cornerRadius);
                 $attrs['ry'] = Tag::formatFloat($this->cornerRadius);
+            }
+            if ($this->animated) {
+                $tfo = $value >= 0.0 ? 'center bottom' : 'center top';
+                $delay = round($i * 0.08, 3);
+                $attrs['style'] = "--svgraph-bar-tfo:{$tfo};--svgraph-bar-delay:{$delay}s;";
             }
             $tipText = $this->tooltip($point->label, $value);
             $rect = Tag::make('rect', $attrs)->append(Tag::make('title')->append($tipText));
@@ -272,6 +280,10 @@ class BarChart extends AbstractChart
         $chartId = $this->chartId();
         $baseX = $xScale->map(0.0);
         $wrapper->markHasSeriesElements();
+        if ($this->animated) {
+            $wrapper->enableAnimation();
+            $wrapper->setSecondaryVariant('bar-h');
+        }
         foreach ($this->series->points as $i => $point) {
             $value = $point->value;
             $y = $viewport->plotTop() + $i * $slotHeight + $barOffset;
@@ -292,6 +304,11 @@ class BarChart extends AbstractChart
             if ($this->cornerRadius > 0.0) {
                 $attrs['rx'] = Tag::formatFloat($this->cornerRadius);
                 $attrs['ry'] = Tag::formatFloat($this->cornerRadius);
+            }
+            if ($this->animated) {
+                $tfo = $value >= 0.0 ? 'left center' : 'right center';
+                $delay = round($i * 0.08, 3);
+                $attrs['style'] = "--svgraph-bar-tfo:{$tfo};--svgraph-bar-delay:{$delay}s;";
             }
             $tipText = $this->tooltip($point->label, $value);
             $rect = Tag::make('rect', $attrs)->append(Tag::make('title')->append($tipText));

--- a/src/Charts/LineChart.php
+++ b/src/Charts/LineChart.php
@@ -171,7 +171,7 @@ class LineChart extends AbstractChart
         }
 
         $lineD = $this->smooth ? Path::smoothLine($points) : Path::line($points);
-        $wrapper->add(Tag::void('path', [
+        $lineAttrs = [
             'd' => $lineD,
             'fill' => 'none',
             'stroke' => $stroke,
@@ -179,7 +179,13 @@ class LineChart extends AbstractChart
             'stroke-linecap' => 'round',
             'stroke-linejoin' => 'round',
             'vector-effect' => 'non-scaling-stroke',
-        ]));
+        ];
+        if ($this->animated) {
+            $lineAttrs['class'] = 'svgraph-line-path';
+            $lineAttrs['pathLength'] = '1';
+            $wrapper->enableAnimation();
+        }
+        $wrapper->add(Tag::void('path', $lineAttrs));
 
         if ($this->showPoints) {
             $chartId = $this->chartId();

--- a/src/Charts/PieChart.php
+++ b/src/Charts/PieChart.php
@@ -101,6 +101,29 @@ class PieChart extends AbstractChart
 
         $wrapper->markHasSeriesElements();
 
+        if ($this->animated) {
+            $wrapper->enableAnimation();
+            $this->renderAnimated($wrapper, $viewport, $chartId, $cx, $cy, $outerRadius, $innerRadius, $total, $startRad, $padRad, $hasLegend);
+        } else {
+            $this->renderStatic($wrapper, $viewport, $chartId, $cx, $cy, $outerRadius, $innerRadius, $total, $startRad, $padRad, $hasLegend);
+        }
+
+        return $wrapper->render();
+    }
+
+    private function renderStatic(
+        Wrapper $wrapper,
+        Viewport $viewport,
+        string $chartId,
+        float $cx,
+        float $cy,
+        float $outerRadius,
+        float $innerRadius,
+        float $total,
+        float $startRad,
+        float $padRad,
+        bool $hasLegend,
+    ): void {
         if ($this->thickness === 0.0 && count($this->slices) === 1) {
             $only = $this->slices[0];
             $color = $only->color ?? $this->theme->colorAt(0);
@@ -123,7 +146,7 @@ class PieChart extends AbstractChart
             if ($hasLegend) {
                 $this->addLegend($wrapper);
             }
-            return $wrapper->render();
+            return;
         }
 
         $angle = $startRad;
@@ -143,8 +166,6 @@ class PieChart extends AbstractChart
             $d = Path::arc($cx, $cy, $outerRadius, $innerRadius, $start, $end);
             $id = "{$chartId}-pt-{$i}";
             $tipText = $this->tooltip($slice->label, $value);
-            // Radial unit vector for the slice centroid — used by CSS to pop the
-            // slice outward via translate(calc(dist * --pop-x), calc(dist * --pop-y)).
             $midAngle = ($start + $end) / 2;
             $popX = round(sin($midAngle), 4);
             $popY = round(-cos($midAngle), 4);
@@ -155,7 +176,6 @@ class PieChart extends AbstractChart
                 'fill' => $color,
             ])->append(Tag::make('title')->append($tipText));
             $wrapper->add($this->buildLink($slice->link, $id, $path));
-            // Anchor the tooltip at the arc centroid.
             $tipRadius = $innerRadius > 0
                 ? ($outerRadius + $innerRadius) / 2
                 : $outerRadius * 0.6;
@@ -172,8 +192,141 @@ class PieChart extends AbstractChart
         if ($hasLegend) {
             $this->addLegend($wrapper);
         }
+    }
 
-        return $wrapper->render();
+    /**
+     * Animated rendering using the stroke-circle technique:
+     * each slice is a circle with stroke-dasharray set to show only its arc
+     * portion, and stroke-dashoffset to position it correctly. The CSS
+     * animation sweeps stroke-dasharray from 0 to the arc length.
+     */
+    private function renderAnimated(
+        Wrapper $wrapper,
+        Viewport $viewport,
+        string $chartId,
+        float $cx,
+        float $cy,
+        float $outerRadius,
+        float $innerRadius,
+        float $total,
+        float $startRad,
+        float $padRad,
+        bool $hasLegend,
+    ): void {
+        // Stroke-circle geometry: the circle radius sits at the midpoint of the
+        // ring, with stroke-width spanning the full ring width.
+        $strokeR = $innerRadius > 0.0
+            ? ($outerRadius + $innerRadius) / 2.0
+            : $outerRadius / 2.0;
+        $strokeWidth = $innerRadius > 0.0
+            ? $outerRadius - $innerRadius
+            : $outerRadius;
+        $circumference = 2.0 * M_PI * $strokeR;
+
+        $tipRadius = $innerRadius > 0.0
+            ? ($outerRadius + $innerRadius) / 2.0
+            : $outerRadius * 0.6;
+
+        // Handle single solid-pie slice (thickness=0, one slice).
+        // Any donut or multi-slice case falls through to the loop.
+        if ($this->thickness === 0.0 && count($this->slices) === 1) {
+            $only = $this->slices[0];
+            $color = $only->color ?? $this->theme->colorAt(0);
+            $id = "{$chartId}-pt-0";
+            $tipText = $this->tooltip($only->label, $only->value);
+            $circ = Tag::formatFloat($circumference);
+            $off = Tag::formatFloat($circumference / 4.0 - ($this->startAngle / 360.0) * $circumference);
+            // Full circle: dasharray = circ 0 (entire circumference is the dash).
+            $circle = Tag::make('circle', [
+                'class' => 'series-0',
+                'cx' => Tag::formatFloat($cx),
+                'cy' => Tag::formatFloat($cy),
+                'r' => Tag::formatFloat($strokeR),
+                'fill' => 'none',
+                'stroke' => $color,
+                'stroke-width' => Tag::formatFloat($strokeWidth),
+                'stroke-dasharray' => "{$circ} 0",
+                'stroke-dashoffset' => $off,
+                'style' => "--pop-x:0;--pop-y:0;--svgraph-pie-off:{$off};--svgraph-pie-len:{$circ};--svgraph-pie-circ:{$circ};",
+            ])->append(Tag::make('title')->append($tipText));
+            $wrapper->add($this->buildLink($only->link, $id, $circle));
+            $wrapper->tooltip(new Tooltip(
+                id: $id,
+                text: Tag::escapeText($tipText),
+                leftPct: $cx / $viewport->width * 100,
+                topPct: ($cy - $outerRadius) / $viewport->height * 100,
+            ));
+            if ($hasLegend) {
+                $this->addLegend($wrapper);
+            }
+            return;
+        }
+
+        $startOffsetArc = ($this->startAngle / 360.0) * $circumference;
+        $halfGapArc = $padRad * $strokeR / 2.0;
+        $cumulativeArc = 0.0;
+        $circ = Tag::formatFloat($circumference);
+
+        $angle = $startRad;
+        foreach ($this->slices as $i => $slice) {
+            $value = max(0.0, $slice->value);
+            if ($value <= 0.0) {
+                continue;
+            }
+            $sweepAngle = ($value / $total) * 2.0 * M_PI;
+            $sweepArc = $sweepAngle * $strokeR;
+            $visibleArc = max(0.0, $sweepArc - $padRad * $strokeR);
+
+            if ($visibleArc <= 0.0) {
+                $cumulativeArc += $sweepArc;
+                $angle += $sweepAngle;
+                continue;
+            }
+
+            $dashOffset = $circumference / 4.0 - $startOffsetArc - $cumulativeArc - $halfGapArc;
+            $arcLen = Tag::formatFloat($visibleArc);
+            $gap = Tag::formatFloat(max(0.0, $circumference - $visibleArc));
+            $off = Tag::formatFloat($dashOffset);
+            $delay = round($i * 0.08, 3);
+
+            $midAngle = $angle + $sweepAngle / 2.0;
+            $popX = round(sin($midAngle), 4);
+            $popY = round(-cos($midAngle), 4);
+
+            $color = $slice->color ?? $this->theme->colorAt($i);
+            $id = "{$chartId}-pt-{$i}";
+            $tipText = $this->tooltip($slice->label, $value);
+
+            $circle = Tag::make('circle', [
+                'class' => "series-{$i}",
+                'cx' => Tag::formatFloat($cx),
+                'cy' => Tag::formatFloat($cy),
+                'r' => Tag::formatFloat($strokeR),
+                'fill' => 'none',
+                'stroke' => $color,
+                'stroke-width' => Tag::formatFloat($strokeWidth),
+                'stroke-dasharray' => "{$arcLen} {$gap}",
+                'stroke-dashoffset' => $off,
+                'style' => "--pop-x:{$popX};--pop-y:{$popY};--svgraph-pie-off:{$off};--svgraph-pie-len:{$arcLen};--svgraph-pie-circ:{$circ};animation-delay:{$delay}s;",
+            ])->append(Tag::make('title')->append($tipText));
+
+            $wrapper->add($this->buildLink($slice->link, $id, $circle));
+
+            [$tipX, $tipY] = Path::polar($cx, $cy, $tipRadius, $midAngle);
+            $wrapper->tooltip(new Tooltip(
+                id: $id,
+                text: Tag::escapeText($tipText),
+                leftPct: $tipX / $viewport->width * 100,
+                topPct: $tipY / $viewport->height * 100,
+            ));
+
+            $cumulativeArc += $sweepArc;
+            $angle += $sweepAngle;
+        }
+
+        if ($hasLegend) {
+            $this->addLegend($wrapper);
+        }
     }
 
     protected function addLegend(Wrapper $wrapper): void

--- a/src/Svg/Css.php
+++ b/src/Svg/Css.php
@@ -19,6 +19,8 @@ final class Css
     private const LENGTH_WITH_UNIT = '/\A[0-9]+(?:\.[0-9]+)?(?:px|em|rem|%|pt|vh|vw|ex|ch)\z/';
     private const FONT_FAMILY = '/\A[A-Za-z0-9 ,\-\'"]{1,80}\z/';
     private const NUMBER = '/\A[0-9]+(?:\.[0-9]+)?\z/';
+    private const DURATION = '/\A[0-9]+(?:\.[0-9]+)?(?:ms|s)\z/';
+    private const EASING = '/\A(?:ease(?:-in(?:-out)?|-out)?|linear|step-(?:start|end)|steps\([0-9]+(?:,(?:start|end))?\)|cubic-bezier\(-?[0-9.]+,-?[0-9.]+,-?[0-9.]+,-?[0-9.]+\))\z/';
 
     public static function color(?string $value): ?string
     {
@@ -45,5 +47,17 @@ final class Css
     public static function lengthWithUnit(?string $value): ?string
     {
         return $value !== null && preg_match(self::LENGTH_WITH_UNIT, $value) === 1 ? $value : null;
+    }
+
+    /** Validates a CSS `<time>` value, e.g. "0.6s" or "300ms". */
+    public static function duration(?string $value): ?string
+    {
+        return $value !== null && preg_match(self::DURATION, $value) === 1 ? $value : null;
+    }
+
+    /** Validates a CSS easing keyword or function, e.g. "ease-out" or "cubic-bezier(0.4,0,0.2,1)". */
+    public static function easing(?string $value): ?string
+    {
+        return $value !== null && preg_match(self::EASING, $value) === 1 ? $value : null;
     }
 }

--- a/src/Svg/Wrapper.php
+++ b/src/Svg/Wrapper.php
@@ -33,6 +33,10 @@ final class Wrapper
 
     private bool $hasSeriesElements = false;
 
+    private bool $animated = false;
+
+    private ?string $secondaryVariant = null;
+
     public function __construct(
         private readonly Viewport $viewport,
         private readonly float $aspectRatio,
@@ -70,11 +74,30 @@ final class Wrapper
         return $this;
     }
 
+    public function enableAnimation(): self
+    {
+        $this->animated = true;
+        return $this;
+    }
+
+    /**
+     * Add an extra `svgraph--{variant}` class to the wrapper, used to
+     * distinguish sub-variants (e.g. horizontal bars) for animation CSS.
+     */
+    public function setSecondaryVariant(string $variant): self
+    {
+        $this->secondaryVariant = $variant;
+        return $this;
+    }
+
     public function render(): string
     {
         $paddingBottom = (1.0 / max($this->aspectRatio, 0.01)) * 100.0;
 
         $classes = ['svgraph', 'svgraph--' . $this->variantClass];
+        if ($this->secondaryVariant !== null) {
+            $classes[] = 'svgraph--' . $this->secondaryVariant;
+        }
         if ($this->userClass !== null && $this->userClass !== '') {
             $classes[] = $this->userClass;
         }
@@ -100,6 +123,12 @@ final class Wrapper
                 . "--svgraph-pie-pop-distance:{$popDist};";
         }
 
+        if ($this->animated) {
+            $dur = Css::duration($this->theme->animationDuration) ?? '0.6s';
+            $ease = Css::easing($this->theme->animationEasing) ?? 'ease-out';
+            $wrapperStyle .= "--svgraph-anim-dur:{$dur};--svgraph-anim-ease:{$ease};";
+        }
+
         $svgStyle = 'position:absolute;inset:0;width:100%;height:100%;display:block;overflow:visible;';
 
         $svg = Tag::make('svg', [
@@ -123,7 +152,7 @@ final class Wrapper
             'style' => $wrapperStyle,
         ]);
 
-        if ($this->tooltips !== [] || $this->hasSeriesElements) {
+        if ($this->tooltips !== [] || $this->hasSeriesElements || $this->animated) {
             $div->appendRaw($this->buildStyle());
         }
 
@@ -176,6 +205,10 @@ final class Wrapper
             $css .= $this->buildTooltipStyle();
         }
 
+        if ($this->animated) {
+            $css .= $this->buildAnimationStyle();
+        }
+
         return "<style>{$css}</style>";
     }
 
@@ -207,8 +240,12 @@ final class Wrapper
         // inline CSS custom properties by the PHP renderer.
         $piePop = '.svgraph--pie path[class^="series-"]:hover,'
             . '.svgraph--pie path[class^="series-"]:focus-visible,'
+            . '.svgraph--pie circle[class^="series-"]:hover,'
+            . '.svgraph--pie circle[class^="series-"]:focus-visible,'
             . '.svgraph--donut path[class^="series-"]:hover,'
-            . '.svgraph--donut path[class^="series-"]:focus-visible{'
+            . '.svgraph--donut path[class^="series-"]:focus-visible,'
+            . '.svgraph--donut circle[class^="series-"]:hover,'
+            . '.svgraph--donut circle[class^="series-"]:focus-visible{'
             . 'transform:translate('
             . 'calc(var(--svgraph-pie-pop-distance,3px)*var(--pop-x,0)),'
             . 'calc(var(--svgraph-pie-pop-distance,3px)*var(--pop-y,0))'
@@ -219,9 +256,15 @@ final class Wrapper
             . '.svgraph--pie path[class^="series-"]:hover,'
             . '.svgraph--pie path[class^="series-"]:focus-visible,'
             . '.svgraph--pie a.svgraph-linked:focus-visible path[class^="series-"],'
+            . '.svgraph--pie circle[class^="series-"]:hover,'
+            . '.svgraph--pie circle[class^="series-"]:focus-visible,'
+            . '.svgraph--pie a.svgraph-linked:focus-visible circle[class^="series-"],'
             . '.svgraph--donut path[class^="series-"]:hover,'
             . '.svgraph--donut path[class^="series-"]:focus-visible,'
-            . '.svgraph--donut a.svgraph-linked:focus-visible path[class^="series-"]{'
+            . '.svgraph--donut a.svgraph-linked:focus-visible path[class^="series-"],'
+            . '.svgraph--donut circle[class^="series-"]:hover,'
+            . '.svgraph--donut circle[class^="series-"]:focus-visible,'
+            . '.svgraph--donut a.svgraph-linked:focus-visible circle[class^="series-"]{'
             . 'transform:none;}}';
 
         // Linked elements: cursor + keyboard-focus highlight rules.
@@ -243,7 +286,9 @@ final class Wrapper
             . '.svgraph a.svgraph-linked:focus-visible g[class^="series-"]>ellipse:first-child{'
             . 'filter:brightness(var(--svgraph-hover-brightness,1.2));}'
             . '.svgraph--pie a.svgraph-linked:focus-visible path[class^="series-"],'
-            . '.svgraph--donut a.svgraph-linked:focus-visible path[class^="series-"]{'
+            . '.svgraph--pie a.svgraph-linked:focus-visible circle[class^="series-"],'
+            . '.svgraph--donut a.svgraph-linked:focus-visible path[class^="series-"],'
+            . '.svgraph--donut a.svgraph-linked:focus-visible circle[class^="series-"]{'
             . 'transform:translate('
             . 'calc(var(--svgraph-pie-pop-distance,3px)*var(--pop-x,0)),'
             . 'calc(var(--svgraph-pie-pop-distance,3px)*var(--pop-y,0))'
@@ -271,5 +316,57 @@ final class Wrapper
         }
 
         return $base . '@supports selector(:has(a)){' . $rules . '}';
+    }
+
+    private function buildAnimationStyle(): string
+    {
+        $dur = 'var(--svgraph-anim-dur,0.6s)';
+        $ease = 'var(--svgraph-anim-ease,ease-out)';
+        $css = '';
+
+        // Line / sparkline: stroke-dasharray draw-on using pathLength="1" normalisation.
+        if ($this->variantClass === 'line' || $this->variantClass === 'sparkline') {
+            $css .= '@keyframes svgraph-draw-line{from{stroke-dashoffset:1}to{stroke-dashoffset:0}}'
+                . '.svgraph--' . $this->variantClass . ' .svgraph-line-path{'
+                . 'stroke-dasharray:1;'
+                . 'animation:svgraph-draw-line ' . $dur . ' ' . $ease . ' both;}';
+        }
+
+        // Bar: scale from the baseline edge on enter.
+        if ($this->variantClass === 'bar') {
+            if ($this->secondaryVariant === 'bar-h') {
+                // Horizontal bars grow from left (positive) or right (negative).
+                $css .= '@keyframes svgraph-grow-hbar{from{transform:scaleX(0)}to{transform:scaleX(1)}}'
+                    . '.svgraph--bar.svgraph--bar-h rect[class^="series-"]{'
+                    . 'transform-box:fill-box;'
+                    . 'transform-origin:var(--svgraph-bar-tfo,left center);'
+                    . 'animation:svgraph-grow-hbar ' . $dur . ' ' . $ease . ' both;'
+                    . 'animation-delay:var(--svgraph-bar-delay,0s);}';
+            } else {
+                // Vertical bars grow from bottom (positive) or top (negative).
+                $css .= '@keyframes svgraph-grow-vbar{from{transform:scaleY(0)}to{transform:scaleY(1)}}'
+                    . '.svgraph--bar:not(.svgraph--bar-h) rect[class^="series-"]{'
+                    . 'transform-box:fill-box;'
+                    . 'transform-origin:var(--svgraph-bar-tfo,center bottom);'
+                    . 'animation:svgraph-grow-vbar ' . $dur . ' ' . $ease . ' both;'
+                    . 'animation-delay:var(--svgraph-bar-delay,0s);}';
+            }
+        }
+
+        // Pie / donut: stroke-dasharray sweep using the stroke-circle technique.
+        // Each slice is rendered as a circle with stroke-dasharray; the from state
+        // has dasharray:0 circ (nothing visible) and the to state shows the arc.
+        // stroke-dashoffset stays constant (positions the arc correctly) while
+        // stroke-dasharray animates to reveal the slice.
+        if ($this->variantClass === 'pie' || $this->variantClass === 'donut') {
+            $css .= '@keyframes svgraph-pie-sweep{'
+                . 'from{stroke-dasharray:0 var(--svgraph-pie-circ)}'
+                . 'to{stroke-dasharray:var(--svgraph-pie-len) calc(var(--svgraph-pie-circ) - var(--svgraph-pie-len))}}'
+                . '.svgraph--' . $this->variantClass . ' circle[class^="series-"]{'
+                . 'animation:svgraph-pie-sweep ' . $dur . ' ' . $ease . ' both;'
+                . 'animation-delay:var(--svgraph-pie-delay,0ms);}';
+        }
+
+        return '@media (prefers-reduced-motion:no-preference){' . $css . '}';
     }
 }

--- a/src/Theme.php
+++ b/src/Theme.php
@@ -32,6 +32,11 @@ final readonly class Theme
      * @param string $hoverBrightness   `--svgraph-hover-brightness`   CSS `<number>` passed to brightness(). Default 1.2.
      * @param string $hoverStrokeWidth  `--svgraph-hover-stroke-width` SVG stroke-width added on hover. Default 1.5.
      * @param string $piePopDistance    `--svgraph-pie-pop-distance`   CSS `<length>` (e.g. "3px") pie slices pop outward by on hover. Default "3px".
+     *
+     * Entrance animation tokens — emitted as CSS custom properties when `->animate()` is used:
+     *
+     * @param string $animationDuration `--svgraph-anim-dur`  CSS `<time>` for the animation (e.g. "0.6s"). Default "0.6s".
+     * @param string $animationEasing   `--svgraph-anim-ease` CSS easing function (e.g. "ease-out"). Default "ease-out".
      */
     public function __construct(
         public array $palette,
@@ -50,6 +55,8 @@ final readonly class Theme
         public string $hoverBrightness = '1.2',
         public string $hoverStrokeWidth = '1.5',
         public string $piePopDistance = '3px',
+        public string $animationDuration = '0.6s',
+        public string $animationEasing = 'ease-out',
     ) {}
 
     public static function default(): self
@@ -105,6 +112,8 @@ final readonly class Theme
             hoverBrightness: $this->hoverBrightness,
             hoverStrokeWidth: $this->hoverStrokeWidth,
             piePopDistance: $this->piePopDistance,
+            animationDuration: $this->animationDuration,
+            animationEasing: $this->animationEasing,
         );
     }
 
@@ -137,6 +146,8 @@ final readonly class Theme
             hoverBrightness: $this->hoverBrightness,
             hoverStrokeWidth: $this->hoverStrokeWidth,
             piePopDistance: $this->piePopDistance,
+            animationDuration: $this->animationDuration,
+            animationEasing: $this->animationEasing,
         );
     }
 
@@ -169,6 +180,39 @@ final readonly class Theme
             hoverBrightness: $brightness ?? $this->hoverBrightness,
             hoverStrokeWidth: $strokeWidth ?? $this->hoverStrokeWidth,
             piePopDistance: $piePopDistance ?? $this->piePopDistance,
+            animationDuration: $this->animationDuration,
+            animationEasing: $this->animationEasing,
+        );
+    }
+
+    /**
+     * Return a copy with different animation timing.
+     *
+     * The values are emitted as CSS custom properties on the wrapper element:
+     *   --svgraph-anim-dur, --svgraph-anim-ease
+     * You can also set these properties directly in your own CSS.
+     */
+    public function withAnimation(string $duration, string $easing = 'ease-out'): self
+    {
+        return new self(
+            palette: $this->palette,
+            stroke: $this->stroke,
+            strokeWidth: $this->strokeWidth,
+            fill: $this->fill,
+            textColor: $this->textColor,
+            fontFamily: $this->fontFamily,
+            fontSize: $this->fontSize,
+            gridColor: $this->gridColor,
+            axisColor: $this->axisColor,
+            trackColor: $this->trackColor,
+            tooltipBackground: $this->tooltipBackground,
+            tooltipTextColor: $this->tooltipTextColor,
+            tooltipBorderRadius: $this->tooltipBorderRadius,
+            hoverBrightness: $this->hoverBrightness,
+            hoverStrokeWidth: $this->hoverStrokeWidth,
+            piePopDistance: $this->piePopDistance,
+            animationDuration: $duration,
+            animationEasing: $easing,
         );
     }
 

--- a/tests/Charts/AnimationTest.php
+++ b/tests/Charts/AnimationTest.php
@@ -1,0 +1,360 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noeka\Svgraph\Tests\Charts;
+
+use Noeka\Svgraph\Chart;
+use Noeka\Svgraph\Theme;
+use PHPUnit\Framework\TestCase;
+
+final class AnimationTest extends TestCase
+{
+    // ── Builder API ───────────────────────────────────────────────────────────
+
+    public function test_animate_returns_self_for_chaining(): void
+    {
+        $chart = Chart::line([1, 2, 3]);
+        self::assertSame($chart, $chart->animate());
+    }
+
+    public function test_animate_off_by_default_no_animation_css(): void
+    {
+        $svg = Chart::line([1, 2, 3])->render();
+        self::assertStringNotContainsString('svgraph-draw-line', $svg);
+        self::assertStringNotContainsString('prefers-reduced-motion:no-preference', $svg);
+    }
+
+    public function test_animate_false_disables_animation(): void
+    {
+        $svg = Chart::line([1, 2, 3])->animate(false)->render();
+        self::assertStringNotContainsString('svgraph-draw-line', $svg);
+    }
+
+    // ── Reduced-motion gate ───────────────────────────────────────────────────
+
+    public function test_animation_wrapped_in_no_preference_media_query(): void
+    {
+        $svg = Chart::line([1, 2, 3])->animate()->render();
+        self::assertStringContainsString('prefers-reduced-motion:no-preference', $svg);
+    }
+
+    public function test_animation_keyframes_only_inside_no_preference_block(): void
+    {
+        // Animation keyframes must live inside the no-preference block, not at top level.
+        $svg = Chart::bar(['A' => 1, 'B' => 2])->animate()->render();
+        // The keyframe name must appear inside the no-preference media query.
+        self::assertMatchesRegularExpression(
+            '/prefers-reduced-motion:no-preference\)\{[^}]*svgraph-grow-vbar/',
+            $svg,
+        );
+    }
+
+    // ── Theme animation tokens ────────────────────────────────────────────────
+
+    public function test_animation_emits_anim_dur_custom_property(): void
+    {
+        $svg = Chart::line([1, 2, 3])->animate()->render();
+        self::assertStringContainsString('--svgraph-anim-dur:0.6s', $svg);
+    }
+
+    public function test_animation_emits_anim_ease_custom_property(): void
+    {
+        $svg = Chart::line([1, 2, 3])->animate()->render();
+        self::assertStringContainsString('--svgraph-anim-ease:ease-out', $svg);
+    }
+
+    public function test_with_animation_overrides_theme_tokens(): void
+    {
+        $svg = Chart::bar(['A' => 1])
+            ->animate()
+            ->theme(Theme::default()->withAnimation('0.4s', 'linear'))
+            ->render();
+        self::assertStringContainsString('--svgraph-anim-dur:0.4s', $svg);
+        self::assertStringContainsString('--svgraph-anim-ease:linear', $svg);
+    }
+
+    public function test_with_animation_invalid_duration_falls_back(): void
+    {
+        $svg = Chart::line([1, 2, 3])
+            ->animate()
+            ->theme(Theme::default()->withAnimation('fast', 'ease-out'))
+            ->render();
+        // Invalid duration falls back to the CSS default value.
+        self::assertStringContainsString('--svgraph-anim-dur:0.6s', $svg);
+    }
+
+    public function test_with_animation_invalid_easing_falls_back(): void
+    {
+        $svg = Chart::line([1, 2, 3])
+            ->animate()
+            ->theme(Theme::default()->withAnimation('0.5s', 'bounce;color:red'))
+            ->render();
+        self::assertStringContainsString('--svgraph-anim-ease:ease-out', $svg);
+    }
+
+    public function test_with_animation_preserves_other_theme_properties(): void
+    {
+        $base = Theme::default()->withPalette('#123456');
+        $themed = $base->withAnimation('1s', 'linear');
+        self::assertSame(['#123456'], $themed->palette);
+        self::assertSame('1s', $themed->animationDuration);
+        self::assertSame('linear', $themed->animationEasing);
+    }
+
+    // ── Line chart animation ──────────────────────────────────────────────────
+
+    public function test_line_animation_emits_draw_line_keyframe(): void
+    {
+        $svg = Chart::line([1, 2, 3, 4])->animate()->render();
+        self::assertStringContainsString('svgraph-draw-line', $svg);
+        self::assertStringContainsString('stroke-dashoffset', $svg);
+    }
+
+    public function test_line_animation_adds_path_length_attribute(): void
+    {
+        $svg = Chart::line([1, 2, 3])->animate()->render();
+        self::assertStringContainsString('pathLength="1"', $svg);
+    }
+
+    public function test_line_animation_adds_line_path_class(): void
+    {
+        $svg = Chart::line([1, 2, 3])->animate()->render();
+        self::assertStringContainsString('class="svgraph-line-path"', $svg);
+    }
+
+    public function test_line_animation_targets_correct_variant_class(): void
+    {
+        $svg = Chart::line([1, 2, 3])->animate()->render();
+        self::assertStringContainsString('.svgraph--line .svgraph-line-path', $svg);
+    }
+
+    public function test_sparkline_animation_targets_sparkline_variant(): void
+    {
+        $svg = Chart::sparkline([1, 2, 3])->animate()->render();
+        self::assertStringContainsString('.svgraph--sparkline .svgraph-line-path', $svg);
+        self::assertStringContainsString('pathLength="1"', $svg);
+    }
+
+    public function test_line_without_animate_has_no_path_length(): void
+    {
+        $svg = Chart::line([1, 2, 3])->render();
+        self::assertStringNotContainsString('pathLength', $svg);
+        self::assertStringNotContainsString('svgraph-line-path', $svg);
+    }
+
+    // ── Bar chart animation ───────────────────────────────────────────────────
+
+    public function test_vertical_bar_animation_emits_grow_vbar_keyframe(): void
+    {
+        $svg = Chart::bar(['A' => 1, 'B' => 2])->animate()->render();
+        self::assertStringContainsString('svgraph-grow-vbar', $svg);
+        self::assertStringContainsString('scaleY(0)', $svg);
+    }
+
+    public function test_vertical_bar_animation_emits_transform_origin_property(): void
+    {
+        $svg = Chart::bar(['A' => 1, 'B' => 2])->animate()->render();
+        self::assertStringContainsString('--svgraph-bar-tfo', $svg);
+        self::assertStringContainsString('center bottom', $svg);
+    }
+
+    public function test_vertical_bar_negative_value_uses_center_top_origin(): void
+    {
+        $svg = Chart::bar(['A' => 5, 'B' => -3])->animate()->render();
+        self::assertStringContainsString('center bottom', $svg);
+        self::assertStringContainsString('center top', $svg);
+    }
+
+    public function test_vertical_bar_animation_emits_stagger_delay(): void
+    {
+        $svg = Chart::bar(['A' => 1, 'B' => 2, 'C' => 3])->animate()->render();
+        self::assertStringContainsString('--svgraph-bar-delay:0s', $svg);
+        self::assertStringContainsString('--svgraph-bar-delay:0.08s', $svg);
+        self::assertStringContainsString('--svgraph-bar-delay:0.16s', $svg);
+    }
+
+    public function test_horizontal_bar_animation_emits_grow_hbar_keyframe(): void
+    {
+        $svg = Chart::bar(['A' => 1, 'B' => 2])->horizontal()->animate()->render();
+        self::assertStringContainsString('svgraph-grow-hbar', $svg);
+        self::assertStringContainsString('scaleX(0)', $svg);
+    }
+
+    public function test_horizontal_bar_animation_adds_bar_h_variant_class(): void
+    {
+        $svg = Chart::bar(['A' => 1, 'B' => 2])->horizontal()->animate()->render();
+        self::assertStringContainsString('svgraph--bar-h', $svg);
+    }
+
+    public function test_horizontal_bar_animation_emits_left_center_origin(): void
+    {
+        $svg = Chart::bar(['A' => 5, 'B' => 8])->horizontal()->animate()->render();
+        self::assertStringContainsString('left center', $svg);
+    }
+
+    public function test_horizontal_bar_negative_uses_right_center_origin(): void
+    {
+        $svg = Chart::bar(['A' => 5, 'B' => -3])->horizontal()->animate()->render();
+        self::assertStringContainsString('left center', $svg);
+        self::assertStringContainsString('right center', $svg);
+    }
+
+    public function test_non_animated_bar_has_no_bar_h_variant(): void
+    {
+        $svg = Chart::bar(['A' => 1])->horizontal()->render();
+        self::assertStringNotContainsString('svgraph--bar-h', $svg);
+    }
+
+    public function test_bar_animation_scaleY_inside_no_preference_media(): void
+    {
+        $svg = Chart::bar(['A' => 1, 'B' => 2])->animate()->render();
+        // scaleY must appear only inside @media (prefers-reduced-motion:no-preference).
+        self::assertMatchesRegularExpression(
+            '/prefers-reduced-motion:no-preference\)[^<]*scaleY/',
+            $svg,
+        );
+    }
+
+    // ── Pie / donut chart animation ───────────────────────────────────────────
+
+    public function test_pie_animation_emits_sweep_keyframe(): void
+    {
+        $svg = Chart::pie(['A' => 50, 'B' => 30, 'C' => 20])->animate()->render();
+        self::assertStringContainsString('svgraph-pie-sweep', $svg);
+        self::assertStringContainsString('stroke-dasharray', $svg);
+    }
+
+    public function test_pie_animation_uses_stroke_circles_not_paths(): void
+    {
+        $svg = Chart::pie(['A' => 50, 'B' => 30, 'C' => 20])->animate()->render();
+        // Animated pie uses circles (stroke-based) instead of filled paths.
+        self::assertSame(0, substr_count($svg, '<path '));
+        self::assertGreaterThanOrEqual(3, substr_count($svg, '<circle '));
+    }
+
+    public function test_pie_animation_circles_have_stroke_dasharray(): void
+    {
+        $svg = Chart::pie(['A' => 50, 'B' => 50])->animate()->render();
+        self::assertMatchesRegularExpression('/stroke-dasharray="[0-9.]+ [0-9.]+"/', $svg);
+    }
+
+    public function test_pie_animation_circles_have_stroke_dashoffset(): void
+    {
+        $svg = Chart::pie(['A' => 50, 'B' => 50])->animate()->render();
+        self::assertStringContainsString('stroke-dashoffset=', $svg);
+    }
+
+    public function test_pie_animation_circles_have_pop_vectors(): void
+    {
+        $svg = Chart::pie(['A' => 50, 'B' => 50])->animate()->render();
+        self::assertMatchesRegularExpression('/style="--pop-x:[^"]+--pop-y:[^"]+"/', $svg);
+    }
+
+    public function test_pie_animation_circles_have_pie_custom_properties(): void
+    {
+        $svg = Chart::pie(['A' => 50, 'B' => 50])->animate()->render();
+        self::assertStringContainsString('--svgraph-pie-off:', $svg);
+        self::assertStringContainsString('--svgraph-pie-len:', $svg);
+        self::assertStringContainsString('--svgraph-pie-circ:', $svg);
+    }
+
+    public function test_pie_animation_emits_stagger_delay_on_slices(): void
+    {
+        $svg = Chart::pie(['A' => 1, 'B' => 1, 'C' => 1])->animate()->render();
+        // Slice 0: 0s, slice 1: 0.08s, slice 2: 0.16s
+        self::assertStringContainsString('animation-delay:0s', $svg);
+        self::assertStringContainsString('animation-delay:0.08s', $svg);
+        self::assertStringContainsString('animation-delay:0.16s', $svg);
+    }
+
+    public function test_pie_animation_single_slice_uses_stroke_circle(): void
+    {
+        $svg = Chart::pie(['Only' => 100])->animate()->render();
+        // Single-slice animated pie also uses stroke-circle rendering.
+        self::assertStringContainsString('stroke-dasharray=', $svg);
+        self::assertStringContainsString('fill="none"', $svg);
+        self::assertStringContainsString('stroke=', $svg);
+    }
+
+    public function test_donut_animation_uses_stroke_circles(): void
+    {
+        $svg = Chart::donut(['A' => 3, 'B' => 1])->animate()->render();
+        self::assertStringContainsString('svgraph-pie-sweep', $svg);
+        self::assertStringContainsString('--svgraph-pie-len:', $svg);
+    }
+
+    public function test_pie_animation_targets_correct_variant(): void
+    {
+        $svg = Chart::pie(['A' => 1, 'B' => 1])->animate()->render();
+        self::assertStringContainsString('.svgraph--pie circle[class^="series-"]', $svg);
+    }
+
+    public function test_donut_animation_targets_donut_variant(): void
+    {
+        $svg = Chart::donut(['A' => 1, 'B' => 1])->animate()->render();
+        self::assertStringContainsString('.svgraph--donut circle[class^="series-"]', $svg);
+    }
+
+    public function test_non_animated_pie_still_uses_paths(): void
+    {
+        $svg = Chart::pie(['A' => 50, 'B' => 30, 'C' => 20])->render();
+        self::assertSame(3, substr_count($svg, '<path '));
+        self::assertStringNotContainsString('stroke-dasharray', $svg);
+    }
+
+    public function test_pie_animation_with_gap_renders_reduced_arc(): void
+    {
+        $noGap = Chart::pie(['A' => 1, 'B' => 1])->animate()->render();
+        $withGap = Chart::pie(['A' => 1, 'B' => 1])->gap(5)->animate()->render();
+        // Gaps produce different dasharray values.
+        self::assertNotSame($noGap, $withGap);
+    }
+
+    public function test_pie_animation_with_legend_still_renders(): void
+    {
+        $svg = Chart::pie(['Stripe' => 100, 'PayPal' => 50])->legend()->animate()->render();
+        self::assertStringContainsString('svgraph__labels', $svg);
+        self::assertStringContainsString('svgraph-pie-sweep', $svg);
+    }
+
+    // ── Hover pop still works on animated pie circles ─────────────────────────
+
+    public function test_hover_pop_css_includes_circle_selectors_for_pie(): void
+    {
+        // Even non-animated pies get the circle selector in hover CSS (for
+        // the single-slice case and future animated usage).
+        $svg = Chart::pie(['A' => 1, 'B' => 1])->render();
+        self::assertStringContainsString('.svgraph--pie circle[class^="series-"]:hover', $svg);
+    }
+
+    public function test_reduced_motion_suppresses_pop_on_pie_circles(): void
+    {
+        $svg = Chart::pie(['A' => 1, 'B' => 1])->render();
+        self::assertMatchesRegularExpression(
+            '/prefers-reduced-motion:reduce\).*circle\[class\^="series-"\].*transform:none/s',
+            $svg,
+        );
+    }
+
+    // ── No animation on empty charts ──────────────────────────────────────────
+
+    public function test_empty_line_chart_with_animate_no_animation_css(): void
+    {
+        $svg = Chart::line([])->animate()->render();
+        self::assertStringNotContainsString('svgraph-draw-line', $svg);
+        self::assertStringNotContainsString('prefers-reduced-motion:no-preference', $svg);
+    }
+
+    public function test_empty_bar_chart_with_animate_no_animation_css(): void
+    {
+        $svg = Chart::bar([])->animate()->render();
+        self::assertStringNotContainsString('svgraph-grow-vbar', $svg);
+    }
+
+    public function test_empty_pie_chart_with_animate_no_animation_css(): void
+    {
+        $svg = Chart::pie([])->animate()->render();
+        self::assertStringNotContainsString('svgraph-pie-sweep', $svg);
+    }
+}


### PR DESCRIPTION
Add opt-in entrance animations via ->animate() on all chart types:

- Line/sparkline: stroke-dashoffset draw-on using pathLength="1" normalisation
- Bar (vertical): scaleY from baseline, transform-origin set per-bar via
  CSS custom property to handle negative values correctly
- Bar (horizontal): scaleX with svgraph--bar-h secondary variant class
- Pie/donut: stroke-dasharray sweep using the stroke-circle technique;
  slices stagger with 80 ms offset per slice index

All animation CSS lives inside @media (prefers-reduced-motion:no-preference),
so users with reduced-motion preferences always receive a static chart.

Duration and easing are theme-tokenised (animationDuration, animationEasing)
and emitted as --svgraph-anim-dur / --svgraph-anim-ease custom properties on
the wrapper element. Theme::withAnimation() overrides both tokens.

Also adds Css::duration() and Css::easing() validators, extends buildHoverStyle()
to include circle selectors for animated-pie hover-pop, and documents the
feature in README.md with 56 new tests in AnimationTest.php.

https://claude.ai/code/session_01HYe1kbQLjQQrNUAKfLLQzX