### PR TITLE
First-class multi-series for line and bar charts (issue #11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,40 @@ Chart::bar($data)->horizontal()->rainbow()->rounded(1)
 | `->axes()` | Show axis line and tick labels |
 | `->grid()` | Show grid lines |
 
+### Multi-series
+
+Line and bar charts accept multiple series. Each series carries its own
+optional name and colour, and the y-axis auto-extends to fit them all.
+
+```php
+use Noeka\Svgraph\Chart;
+use Noeka\Svgraph\Data\Series;
+
+// Two-line chart, distinct colours, hover tooltips include the series name.
+Chart::line(['Jan' => 12, 'Feb' => 27, 'Mar' => 18])
+    ->addSeries(Series::of('Costs', ['Jan' => 6, 'Feb' => 14, 'Mar' => 9], '#ef4444'))
+    ->axes()->grid()->points()
+```
+
+For bar charts, two extra modes pick how multiple series share each x-tick:
+
+```php
+// Grouped (default for multi-series): bars sit side-by-side per slot.
+Chart::bar(['Q1' => 10, 'Q2' => 20])
+    ->addSeries(Series::of('Costs', ['Q1' => 5, 'Q2' => 8]))
+    ->grouped()
+    ->axes()
+
+// Stacked: bars stack atop each other; y-axis grows to the cumulative sum.
+Chart::bar(['Q1' => 10, 'Q2' => 20])
+    ->addSeries(Series::of('Costs', ['Q1' => 5, 'Q2' => 8]))
+    ->stacked()
+    ->axes()
+```
+
+Each rendered shape carries a `.series-{N}` class so external CSS can target
+individual series.
+
 ### Pie
 
 ```php

--- a/src/Charts/BarChart.php
+++ b/src/Charts/BarChart.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Noeka\Svgraph\Charts;
 
 use Noeka\Svgraph\Data\Series;
+use Noeka\Svgraph\Data\SeriesCollection;
 use Noeka\Svgraph\Geometry\Scale;
 use Noeka\Svgraph\Geometry\Viewport;
 use Noeka\Svgraph\Svg\Label;
@@ -14,7 +15,11 @@ use Noeka\Svgraph\Svg\Wrapper;
 
 class BarChart extends AbstractChart
 {
-    protected Series $series;
+    private const MODE_AUTO = 'auto';
+    private const MODE_GROUPED = 'grouped';
+    private const MODE_STACKED = 'stacked';
+
+    protected SeriesCollection $seriesCollection;
 
     protected ?string $color = null;
     protected float $gap = 0.2;
@@ -25,18 +30,32 @@ class BarChart extends AbstractChart
     protected int $tickCount = 5;
     protected bool $useColorPerBar = false;
 
+    protected string $mode = self::MODE_AUTO;
+
     public function __construct()
     {
         parent::__construct();
         $this->variantClass = 'bar';
         $this->aspectRatio = 2.0;
-        $this->series = new Series([]);
+        $this->seriesCollection = new SeriesCollection();
     }
 
     /** @param iterable<mixed> $data */
     public function data(iterable $data): static
     {
-        $this->series = Series::from($data);
+        $this->seriesCollection = new SeriesCollection([Series::from($data)]);
+        return $this;
+    }
+
+    /**
+     * Append a series. The first call to `data()` (or `addSeries()` on an
+     * empty chart) seeds series 0; subsequent `addSeries()` calls append.
+     * Multi-series charts default to grouped layout — call `stacked()` to
+     * stack bars instead.
+     */
+    public function addSeries(Series $series): static
+    {
+        $this->seriesCollection = $this->seriesCollection->with($series);
         return $this;
     }
 
@@ -48,6 +67,8 @@ class BarChart extends AbstractChart
 
     /**
      * Use the theme palette to color each bar individually.
+     * Only applies to single-series charts; multi-series charts already
+     * pick a per-series colour from the palette.
      */
     public function rainbow(bool $on = true): static
     {
@@ -94,9 +115,29 @@ class BarChart extends AbstractChart
         return $this;
     }
 
+    /**
+     * Place bars side-by-side per X tick across all series. Default for
+     * multi-series charts.
+     */
+    public function grouped(bool $on = true): static
+    {
+        $this->mode = $on ? self::MODE_GROUPED : self::MODE_AUTO;
+        return $this;
+    }
+
+    /**
+     * Stack bars atop each other per X tick. Y axis grows to the cumulative
+     * max sum, not the largest single value.
+     */
+    public function stacked(bool $on = true): static
+    {
+        $this->mode = $on ? self::MODE_STACKED : self::MODE_AUTO;
+        return $this;
+    }
+
     public function render(): string
     {
-        if ($this->series->isEmpty()) {
+        if ($this->seriesCollection->isEmpty()) {
             $viewport = new Viewport();
             $wrapper = new Wrapper($viewport, $this->aspectRatio, $this->variantClass, $this->theme);
             $wrapper->setUserClass($this->cssClass);
@@ -106,9 +147,27 @@ class BarChart extends AbstractChart
         return $this->horizontal ? $this->renderHorizontal() : $this->renderVertical();
     }
 
+    /**
+     * `auto` is grouped — single series naturally collapses into one bar
+     * per slot since the per-slot bar count equals the series count.
+     */
+    private function effectiveMode(): string
+    {
+        return $this->mode === self::MODE_AUTO ? self::MODE_GROUPED : $this->mode;
+    }
+
+    /**
+     * For animation staggering: index in the rendering order so visually
+     * adjacent bars wave in together.
+     */
+    private function staggerDelay(int $position): string
+    {
+        return (string) round($position * 0.08, 3);
+    }
+
     protected function renderVertical(): string
     {
-        $hasLabels = $this->series->hasLabels();
+        $hasLabels = $this->seriesCollection->hasLabels();
         $padTop = $this->showAxes || $this->showGrid ? 4.0 : 0.0;
         $padRight = $this->showAxes || $this->showGrid ? 2.0 : 0.0;
         $padBottom = $hasLabels ? ($this->showAxes ? 14.0 : 8.0) : 0.0;
@@ -118,21 +177,26 @@ class BarChart extends AbstractChart
         $wrapper = new Wrapper($viewport, $this->aspectRatio, $this->variantClass, $this->theme);
         $wrapper->setUserClass($this->cssClass);
 
-        $values = $this->series->values();
-        if ($values === []) {
+        $maxLen = $this->seriesCollection->maxLength();
+        if ($maxLen === 0) {
             return $wrapper->render();
         }
-        $count = count($values);
-        $max = max($values);
-        $min = min(0.0, min($values));
-        if ($min === $max) {
-            $max += 1.0;
+
+        $mode = $this->effectiveMode();
+        if ($mode === self::MODE_STACKED) {
+            $domainMin = min(0.0, $this->seriesCollection->stackedMin());
+            $domainMax = $this->seriesCollection->stackedMax();
+        } else {
+            $domainMin = min(0.0, $this->seriesCollection->valueMin());
+            $domainMax = $this->seriesCollection->valueMax();
+        }
+        if ($domainMin === $domainMax) {
+            $domainMax += 1.0;
         }
 
-        $yScale = Scale::linear($min, $max, $viewport->plotTop(), $viewport->plotBottom(), invert: true);
-        $slotWidth = $viewport->plotWidth() / $count;
-        $barWidth = $slotWidth * (1.0 - $this->gap);
-        $barOffset = ($slotWidth - $barWidth) / 2.0;
+        $yScale = Scale::linear($domainMin, $domainMax, $viewport->plotTop(), $viewport->plotBottom(), invert: true);
+        $slotWidth = $viewport->plotWidth() / $maxLen;
+        $baseY = $yScale->map(0.0);
 
         if ($this->showGrid) {
             foreach ($yScale->ticks($this->tickCount) as $tick) {
@@ -149,47 +213,15 @@ class BarChart extends AbstractChart
             }
         }
 
-        $chartId = $this->chartId();
-        $baseY = $yScale->map(0.0);
         $wrapper->markHasSeriesElements();
         if ($this->animated) {
             $wrapper->enableAnimation();
         }
-        foreach ($this->series->points as $i => $point) {
-            $value = $point->value;
-            $x = $viewport->plotLeft() + $i * $slotWidth + $barOffset;
-            $valueY = $yScale->map($value);
-            $top = min($baseY, $valueY);
-            $height = abs($valueY - $baseY);
-            $color = $this->useColorPerBar ? $this->theme->colorAt($i) : ($this->color ?? $this->theme->fill);
-            $seriesIndex = $this->useColorPerBar ? $i : 0;
-            $id = "{$chartId}-pt-{$i}";
-            $attrs = [
-                'class' => "series-{$seriesIndex}",
-                'x' => Tag::formatFloat($x),
-                'y' => Tag::formatFloat($top),
-                'width' => Tag::formatFloat($barWidth),
-                'height' => Tag::formatFloat($height),
-                'fill' => $color,
-            ];
-            if ($this->cornerRadius > 0.0) {
-                $attrs['rx'] = Tag::formatFloat($this->cornerRadius);
-                $attrs['ry'] = Tag::formatFloat($this->cornerRadius);
-            }
-            if ($this->animated) {
-                $tfo = $value >= 0.0 ? 'center bottom' : 'center top';
-                $delay = round($i * 0.08, 3);
-                $attrs['style'] = "--svgraph-bar-tfo:{$tfo};--svgraph-bar-delay:{$delay}s;";
-            }
-            $tipText = $this->tooltip($point->label, $value);
-            $rect = Tag::make('rect', $attrs)->append(Tag::make('title')->append($tipText));
-            $wrapper->add($this->buildLink($point->link, $id, $rect));
-            $wrapper->tooltip(new Tooltip(
-                id: $id,
-                text: Tag::escapeText($tipText),
-                leftPct: ($x + $barWidth / 2) / $viewport->width * 100,
-                topPct: $top / $viewport->height * 100,
-            ));
+
+        if ($mode === self::MODE_STACKED) {
+            $this->renderVerticalStacked($wrapper, $viewport, $yScale, $slotWidth, $baseY);
+        } else {
+            $this->renderVerticalGrouped($wrapper, $viewport, $yScale, $slotWidth, $baseY);
         }
 
         if ($this->showAxes) {
@@ -216,7 +248,7 @@ class BarChart extends AbstractChart
         }
 
         if ($hasLabels) {
-            foreach ($this->series->labels() as $i => $label) {
+            foreach ($this->seriesCollection->commonLabels() as $i => $label) {
                 if ($label === null || $label === '') {
                     continue;
                 }
@@ -234,9 +266,159 @@ class BarChart extends AbstractChart
         return $wrapper->render();
     }
 
+    private function renderVerticalGrouped(
+        Wrapper $wrapper,
+        Viewport $viewport,
+        Scale $yScale,
+        float $slotWidth,
+        float $baseY,
+    ): void {
+        $chartId = $this->chartId();
+        $seriesCount = $this->seriesCollection->count();
+        $groupWidth = $slotWidth * (1.0 - $this->gap);
+        $groupOffset = ($slotWidth - $groupWidth) / 2.0;
+        $barWidth = $groupWidth / $seriesCount;
+        $rainbowSingle = $seriesCount === 1 && $this->useColorPerBar;
+
+        $position = 0;
+        foreach ($this->seriesCollection->items as $j => $series) {
+            $seriesColor = $this->resolveSeriesColor($series, $j);
+            foreach ($series->points as $i => $point) {
+                $value = $point->value;
+                $slotX = $viewport->plotLeft() + $i * $slotWidth + $groupOffset;
+                $x = $slotX + $j * $barWidth;
+                $valueY = $yScale->map($value);
+                $top = min($baseY, $valueY);
+                $height = abs($valueY - $baseY);
+                [$color, $classIndex] = $rainbowSingle
+                    ? [$this->theme->colorAt($i), $i]
+                    : [$seriesColor, $j];
+                $id = "{$chartId}-s{$j}-pt-{$i}";
+                $tipText = $this->tooltip($this->labelFor($series, $point->label), $value);
+                $tfo = $value >= 0.0 ? 'center bottom' : 'center top';
+                $this->emitVerticalBar(
+                    $wrapper,
+                    $viewport,
+                    $id,
+                    $classIndex,
+                    $x,
+                    $top,
+                    $barWidth,
+                    $height,
+                    $color,
+                    $tipText,
+                    $point->link,
+                    $tfo,
+                    $position++,
+                );
+            }
+        }
+    }
+
+    private function renderVerticalStacked(
+        Wrapper $wrapper,
+        Viewport $viewport,
+        Scale $yScale,
+        float $slotWidth,
+        float $baseY,
+    ): void {
+        $chartId = $this->chartId();
+        $barWidth = $slotWidth * (1.0 - $this->gap);
+        $barOffset = ($slotWidth - $barWidth) / 2.0;
+        $maxLen = $this->seriesCollection->maxLength();
+
+        // Track running positive/negative tops per slot so each segment
+        // sits flush against the previous one.
+        $posCursor = array_fill(0, $maxLen, 0.0);
+        $negCursor = array_fill(0, $maxLen, 0.0);
+
+        $position = 0;
+        foreach ($this->seriesCollection->items as $j => $series) {
+            $color = $this->resolveSeriesColor($series, $j);
+            foreach ($series->points as $i => $point) {
+                $value = $point->value;
+                if ($value === 0.0) {
+                    continue;
+                }
+                $x = $viewport->plotLeft() + $i * $slotWidth + $barOffset;
+                if ($value > 0.0) {
+                    $bottomVal = $posCursor[$i];
+                    $topVal = $bottomVal + $value;
+                    $posCursor[$i] = $topVal;
+                } else {
+                    $topVal = $negCursor[$i];
+                    $bottomVal = $topVal + $value;
+                    $negCursor[$i] = $bottomVal;
+                }
+                $topY = $yScale->map(max($topVal, $bottomVal));
+                $bottomY = $yScale->map(min($topVal, $bottomVal));
+                $height = abs($bottomY - $topY);
+                $id = "{$chartId}-s{$j}-pt-{$i}";
+                $tipText = $this->tooltip($this->labelFor($series, $point->label), $value);
+                $tfo = $value >= 0.0 ? 'center bottom' : 'center top';
+                $this->emitVerticalBar(
+                    $wrapper,
+                    $viewport,
+                    $id,
+                    $j,
+                    $x,
+                    $topY,
+                    $barWidth,
+                    $height,
+                    $color,
+                    $tipText,
+                    $point->link,
+                    $tfo,
+                    $position++,
+                );
+            }
+        }
+    }
+
+    private function emitVerticalBar(
+        Wrapper $wrapper,
+        Viewport $viewport,
+        string $id,
+        int $seriesIndex,
+        float $x,
+        float $top,
+        float $width,
+        float $height,
+        string $color,
+        string $tipText,
+        ?\Noeka\Svgraph\Data\Link $link,
+        string $tfo,
+        int $stagger,
+    ): void {
+        $attrs = [
+            'class' => "series-{$seriesIndex}",
+            'x' => Tag::formatFloat($x),
+            'y' => Tag::formatFloat($top),
+            'width' => Tag::formatFloat($width),
+            'height' => Tag::formatFloat($height),
+            'fill' => $color,
+        ];
+        if ($this->cornerRadius > 0.0) {
+            $attrs['rx'] = Tag::formatFloat($this->cornerRadius);
+            $attrs['ry'] = Tag::formatFloat($this->cornerRadius);
+        }
+        if ($this->animated) {
+            $delay = $this->staggerDelay($stagger);
+            $attrs['style'] = "--svgraph-bar-tfo:{$tfo};--svgraph-bar-delay:{$delay}s;";
+        }
+        $rect = Tag::make('rect', $attrs)->append(Tag::make('title')->append($tipText));
+        $wrapper->add($this->buildLink($link, $id, $rect));
+        $wrapper->tooltip(new Tooltip(
+            id: $id,
+            text: Tag::escapeText($tipText),
+            leftPct: ($x + $width / 2) / $viewport->width * 100,
+            topPct: $top / $viewport->height * 100,
+        ));
+    }
+
     protected function renderHorizontal(): string
     {
-        $hasLabels = $this->series->hasLabels();
+        $hasLabels = $this->seriesCollection->hasLabels();
         $padTop = 2.0;
         $padRight = $this->showAxes ? 6.0 : 2.0;
         $padBottom = $this->showAxes ? 8.0 : 2.0;
@@ -246,21 +428,26 @@ class BarChart extends AbstractChart
         $wrapper = new Wrapper($viewport, $this->aspectRatio, $this->variantClass, $this->theme);
         $wrapper->setUserClass($this->cssClass);
 
-        $values = $this->series->values();
-        if ($values === []) {
+        $maxLen = $this->seriesCollection->maxLength();
+        if ($maxLen === 0) {
             return $wrapper->render();
         }
-        $count = count($values);
-        $max = max($values);
-        $min = min(0.0, min($values));
-        if ($min === $max) {
-            $max += 1.0;
+
+        $mode = $this->effectiveMode();
+        if ($mode === self::MODE_STACKED) {
+            $domainMin = min(0.0, $this->seriesCollection->stackedMin());
+            $domainMax = $this->seriesCollection->stackedMax();
+        } else {
+            $domainMin = min(0.0, $this->seriesCollection->valueMin());
+            $domainMax = $this->seriesCollection->valueMax();
+        }
+        if ($domainMin === $domainMax) {
+            $domainMax += 1.0;
         }
 
-        $xScale = Scale::linear($min, $max, $viewport->plotLeft(), $viewport->plotRight());
-        $slotHeight = $viewport->plotHeight() / $count;
-        $barHeight = $slotHeight * (1.0 - $this->gap);
-        $barOffset = ($slotHeight - $barHeight) / 2.0;
+        $xScale = Scale::linear($domainMin, $domainMax, $viewport->plotLeft(), $viewport->plotRight());
+        $slotHeight = $viewport->plotHeight() / $maxLen;
+        $baseX = $xScale->map(0.0);
 
         if ($this->showGrid) {
             foreach ($xScale->ticks($this->tickCount) as $tick) {
@@ -277,52 +464,20 @@ class BarChart extends AbstractChart
             }
         }
 
-        $chartId = $this->chartId();
-        $baseX = $xScale->map(0.0);
         $wrapper->markHasSeriesElements();
         if ($this->animated) {
             $wrapper->enableAnimation();
             $wrapper->setSecondaryVariant('bar-h');
         }
-        foreach ($this->series->points as $i => $point) {
-            $value = $point->value;
-            $y = $viewport->plotTop() + $i * $slotHeight + $barOffset;
-            $valueX = $xScale->map($value);
-            $left = min($baseX, $valueX);
-            $width = abs($valueX - $baseX);
-            $color = $this->useColorPerBar ? $this->theme->colorAt($i) : ($this->color ?? $this->theme->fill);
-            $seriesIndex = $this->useColorPerBar ? $i : 0;
-            $id = "{$chartId}-pt-{$i}";
-            $attrs = [
-                'class' => "series-{$seriesIndex}",
-                'x' => Tag::formatFloat($left),
-                'y' => Tag::formatFloat($y),
-                'width' => Tag::formatFloat($width),
-                'height' => Tag::formatFloat($barHeight),
-                'fill' => $color,
-            ];
-            if ($this->cornerRadius > 0.0) {
-                $attrs['rx'] = Tag::formatFloat($this->cornerRadius);
-                $attrs['ry'] = Tag::formatFloat($this->cornerRadius);
-            }
-            if ($this->animated) {
-                $tfo = $value >= 0.0 ? 'left center' : 'right center';
-                $delay = round($i * 0.08, 3);
-                $attrs['style'] = "--svgraph-bar-tfo:{$tfo};--svgraph-bar-delay:{$delay}s;";
-            }
-            $tipText = $this->tooltip($point->label, $value);
-            $rect = Tag::make('rect', $attrs)->append(Tag::make('title')->append($tipText));
-            $wrapper->add($this->buildLink($point->link, $id, $rect));
-            $wrapper->tooltip(new Tooltip(
-                id: $id,
-                text: Tag::escapeText($tipText),
-                leftPct: ($left + $width) / $viewport->width * 100,
-                topPct: ($y + $barHeight / 2) / $viewport->height * 100,
-            ));
+
+        if ($mode === self::MODE_STACKED) {
+            $this->renderHorizontalStacked($wrapper, $viewport, $xScale, $slotHeight, $baseX);
+        } else {
+            $this->renderHorizontalGrouped($wrapper, $viewport, $xScale, $slotHeight, $baseX);
         }
 
         if ($hasLabels) {
-            foreach ($this->series->labels() as $i => $label) {
+            foreach ($this->seriesCollection->commonLabels() as $i => $label) {
                 if ($label === null || $label === '') {
                     continue;
                 }
@@ -351,5 +506,179 @@ class BarChart extends AbstractChart
         }
 
         return $wrapper->render();
+    }
+
+    private function renderHorizontalGrouped(
+        Wrapper $wrapper,
+        Viewport $viewport,
+        Scale $xScale,
+        float $slotHeight,
+        float $baseX,
+    ): void {
+        $chartId = $this->chartId();
+        $seriesCount = $this->seriesCollection->count();
+        $groupHeight = $slotHeight * (1.0 - $this->gap);
+        $groupOffset = ($slotHeight - $groupHeight) / 2.0;
+        $barHeight = $groupHeight / $seriesCount;
+        $rainbowSingle = $seriesCount === 1 && $this->useColorPerBar;
+
+        $position = 0;
+        foreach ($this->seriesCollection->items as $j => $series) {
+            $seriesColor = $this->resolveSeriesColor($series, $j);
+            foreach ($series->points as $i => $point) {
+                $value = $point->value;
+                $slotY = $viewport->plotTop() + $i * $slotHeight + $groupOffset;
+                $y = $slotY + $j * $barHeight;
+                $valueX = $xScale->map($value);
+                $left = min($baseX, $valueX);
+                $width = abs($valueX - $baseX);
+                [$color, $classIndex] = $rainbowSingle
+                    ? [$this->theme->colorAt($i), $i]
+                    : [$seriesColor, $j];
+                $id = "{$chartId}-s{$j}-pt-{$i}";
+                $tipText = $this->tooltip($this->labelFor($series, $point->label), $value);
+                $tfo = $value >= 0.0 ? 'left center' : 'right center';
+                $this->emitHorizontalBar(
+                    $wrapper,
+                    $viewport,
+                    $id,
+                    $classIndex,
+                    $left,
+                    $y,
+                    $width,
+                    $barHeight,
+                    $color,
+                    $tipText,
+                    $point->link,
+                    $tfo,
+                    $position++,
+                );
+            }
+        }
+    }
+
+    private function renderHorizontalStacked(
+        Wrapper $wrapper,
+        Viewport $viewport,
+        Scale $xScale,
+        float $slotHeight,
+        float $baseX,
+    ): void {
+        $chartId = $this->chartId();
+        $barHeight = $slotHeight * (1.0 - $this->gap);
+        $barOffset = ($slotHeight - $barHeight) / 2.0;
+        $maxLen = $this->seriesCollection->maxLength();
+
+        $posCursor = array_fill(0, $maxLen, 0.0);
+        $negCursor = array_fill(0, $maxLen, 0.0);
+
+        $position = 0;
+        foreach ($this->seriesCollection->items as $j => $series) {
+            $color = $this->resolveSeriesColor($series, $j);
+            foreach ($series->points as $i => $point) {
+                $value = $point->value;
+                if ($value === 0.0) {
+                    continue;
+                }
+                $y = $viewport->plotTop() + $i * $slotHeight + $barOffset;
+                if ($value > 0.0) {
+                    $startVal = $posCursor[$i];
+                    $endVal = $startVal + $value;
+                    $posCursor[$i] = $endVal;
+                } else {
+                    $endVal = $negCursor[$i];
+                    $startVal = $endVal + $value;
+                    $negCursor[$i] = $startVal;
+                }
+                $leftX = $xScale->map(min($startVal, $endVal));
+                $rightX = $xScale->map(max($startVal, $endVal));
+                $width = abs($rightX - $leftX);
+                $id = "{$chartId}-s{$j}-pt-{$i}";
+                $tipText = $this->tooltip($this->labelFor($series, $point->label), $value);
+                $tfo = $value >= 0.0 ? 'left center' : 'right center';
+                $this->emitHorizontalBar(
+                    $wrapper,
+                    $viewport,
+                    $id,
+                    $j,
+                    $leftX,
+                    $y,
+                    $width,
+                    $barHeight,
+                    $color,
+                    $tipText,
+                    $point->link,
+                    $tfo,
+                    $position++,
+                );
+            }
+        }
+    }
+
+    private function emitHorizontalBar(
+        Wrapper $wrapper,
+        Viewport $viewport,
+        string $id,
+        int $seriesIndex,
+        float $left,
+        float $y,
+        float $width,
+        float $height,
+        string $color,
+        string $tipText,
+        ?\Noeka\Svgraph\Data\Link $link,
+        string $tfo,
+        int $stagger,
+    ): void {
+        $attrs = [
+            'class' => "series-{$seriesIndex}",
+            'x' => Tag::formatFloat($left),
+            'y' => Tag::formatFloat($y),
+            'width' => Tag::formatFloat($width),
+            'height' => Tag::formatFloat($height),
+            'fill' => $color,
+        ];
+        if ($this->cornerRadius > 0.0) {
+            $attrs['rx'] = Tag::formatFloat($this->cornerRadius);
+            $attrs['ry'] = Tag::formatFloat($this->cornerRadius);
+        }
+        if ($this->animated) {
+            $delay = $this->staggerDelay($stagger);
+            $attrs['style'] = "--svgraph-bar-tfo:{$tfo};--svgraph-bar-delay:{$delay}s;";
+        }
+        $rect = Tag::make('rect', $attrs)->append(Tag::make('title')->append($tipText));
+        $wrapper->add($this->buildLink($link, $id, $rect));
+        $wrapper->tooltip(new Tooltip(
+            id: $id,
+            text: Tag::escapeText($tipText),
+            leftPct: ($left + $width) / $viewport->width * 100,
+            topPct: ($y + $height / 2) / $viewport->height * 100,
+        ));
+    }
+
+    /**
+     * Per-series color: explicit Series->color wins, then chart-level
+     * `->color()` for series 0 (so single-series `Chart::bar()->color()`
+     * stays ergonomic), then the theme palette.
+     */
+    private function resolveSeriesColor(Series $series, int $index): string
+    {
+        if ($series->color !== null) {
+            return $series->color;
+        }
+        if ($index === 0 && $this->color !== null) {
+            return $this->color;
+        }
+        return $this->theme->colorAt($index);
+    }
+
+    private function labelFor(Series $series, ?string $pointLabel): ?string
+    {
+        if ($series->name !== '') {
+            return $pointLabel === null || $pointLabel === ''
+                ? $series->name
+                : "{$series->name} — {$pointLabel}";
+        }
+        return $pointLabel;
     }
 }

--- a/src/Charts/LineChart.php
+++ b/src/Charts/LineChart.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Noeka\Svgraph\Charts;
 
 use Noeka\Svgraph\Data\Series;
+use Noeka\Svgraph\Data\SeriesCollection;
 use Noeka\Svgraph\Geometry\Path;
 use Noeka\Svgraph\Geometry\Scale;
 use Noeka\Svgraph\Geometry\Viewport;
@@ -15,7 +16,7 @@ use Noeka\Svgraph\Svg\Wrapper;
 
 class LineChart extends AbstractChart
 {
-    protected Series $series;
+    protected SeriesCollection $seriesCollection;
 
     protected ?string $strokeColor = null;
     protected ?float $strokeWidth = null;
@@ -35,13 +36,13 @@ class LineChart extends AbstractChart
     {
         parent::__construct();
         $this->variantClass = 'line';
-        $this->series = new Series([]);
+        $this->seriesCollection = new SeriesCollection();
     }
 
     /** @param iterable<mixed> $data */
     public function series(iterable $data): static
     {
-        $this->series = Series::from($data);
+        $this->seriesCollection = new SeriesCollection([Series::from($data)]);
         return $this;
     }
 
@@ -49,6 +50,16 @@ class LineChart extends AbstractChart
     public function data(iterable $data): static
     {
         return $this->series($data);
+    }
+
+    /**
+     * Append a series. Combine with `data()` (which sets the first) or call
+     * `addSeries()` repeatedly to build up the chart series-by-series.
+     */
+    public function addSeries(Series $series): static
+    {
+        $this->seriesCollection = $this->seriesCollection->with($series);
+        return $this;
     }
 
     public function stroke(string $color, ?float $width = null): static
@@ -106,11 +117,11 @@ class LineChart extends AbstractChart
 
     public function render(): string
     {
-        if ($this->series->isEmpty()) {
+        if ($this->seriesCollection->isEmpty()) {
             return $this->renderEmpty();
         }
 
-        $hasLabels = $this->series->hasLabels();
+        $hasLabels = $this->seriesCollection->hasLabels();
         $padTop = $this->showAxes || $this->showGrid ? 4.0 : 0.0;
         $padRight = $this->showAxes || $this->showGrid ? 2.0 : 0.0;
         $padBottom = $hasLabels && ($this->showAxes || $this->showGrid) ? 14.0 : 0.0;
@@ -118,13 +129,13 @@ class LineChart extends AbstractChart
 
         $viewport = new Viewport(100, 100, $padTop, $padRight, $padBottom, $padLeft);
 
-        $values = $this->series->values();
-        if ($values === []) {
+        $maxLen = $this->seriesCollection->maxLength();
+        if ($maxLen === 0) {
             return $this->renderEmpty();
         }
-        $count = count($values);
-        $min = min($values);
-        $max = max($values);
+
+        $min = $this->seriesCollection->valueMin();
+        $max = $this->seriesCollection->valueMax();
         if ($min === $max) {
             $min -= 1.0;
             $max += 1.0;
@@ -133,17 +144,10 @@ class LineChart extends AbstractChart
         $domainMin = $min - $padding;
         $domainMax = $max + $padding;
 
-        $xScale = Scale::linear(0, max(1, $count - 1), $viewport->plotLeft(), $viewport->plotRight());
+        $xScale = Scale::linear(0, max(1, $maxLen - 1), $viewport->plotLeft(), $viewport->plotRight());
         $yScale = Scale::linear($domainMin, $domainMax, $viewport->plotTop(), $viewport->plotBottom(), invert: true);
 
-        $points = [];
-        foreach ($values as $i => $v) {
-            $points[] = [$xScale->map((float) $i), $yScale->map($v)];
-        }
-
-        $stroke = $this->strokeColor ?? $this->theme->stroke;
         $strokeWidth = $this->strokeWidth ?? $this->theme->strokeWidth;
-        $fillColor = $this->fillColor ?? $stroke;
 
         $wrapper = new Wrapper($viewport, $this->aspectRatio, $this->variantClass, $this->theme);
         $wrapper->setUserClass($this->cssClass);
@@ -160,9 +164,45 @@ class LineChart extends AbstractChart
             }
         }
 
+        if ($this->animated) {
+            $wrapper->enableAnimation();
+        }
+
+        foreach ($this->seriesCollection->items as $i => $series) {
+            $this->renderSeries($wrapper, $series, $i, $xScale, $yScale, $viewport, $strokeWidth);
+        }
+
+        if ($this->showAxes) {
+            $this->addLabels($wrapper, $xScale, $yScale);
+        }
+
+        return $wrapper->render();
+    }
+
+    private function renderSeries(
+        Wrapper $wrapper,
+        Series $series,
+        int $index,
+        Scale $xScale,
+        Scale $yScale,
+        Viewport $viewport,
+        float $strokeWidth,
+    ): void {
+        if ($series->isEmpty()) {
+            return;
+        }
+
+        $color = $this->resolveColor($series, $index);
+        $points = [];
+        foreach ($series->values as $i => $v) {
+            $points[] = [$xScale->map((float) $i), $yScale->map($v)];
+        }
+
         if ($this->fillEnabled) {
+            $fillColor = $this->fillColor ?? $color;
             $areaD = Path::area($points, $viewport->plotBottom(), $this->smooth);
             $wrapper->add(Tag::void('path', [
+                'class' => "series-{$index}",
                 'd' => $areaD,
                 'fill' => $fillColor,
                 'fill-opacity' => Tag::formatFloat($this->fillOpacity),
@@ -172,71 +212,108 @@ class LineChart extends AbstractChart
 
         $lineD = $this->smooth ? Path::smoothLine($points) : Path::line($points);
         $lineAttrs = [
+            'class' => "series-{$index}",
             'd' => $lineD,
             'fill' => 'none',
-            'stroke' => $stroke,
+            'stroke' => $color,
             'stroke-width' => Tag::formatFloat($strokeWidth),
             'stroke-linecap' => 'round',
             'stroke-linejoin' => 'round',
             'vector-effect' => 'non-scaling-stroke',
         ];
         if ($this->animated) {
-            $lineAttrs['class'] = 'svgraph-line-path';
+            $lineAttrs['class'] = "series-{$index} svgraph-line-path";
             $lineAttrs['pathLength'] = '1';
-            $wrapper->enableAnimation();
         }
         $wrapper->add(Tag::void('path', $lineAttrs));
 
         if ($this->showPoints) {
-            $chartId = $this->chartId();
-            $r = $strokeWidth * 0.6;
-            $rx = $r / max(0.01, $this->aspectRatio);
-            $hitR = max(4.0, $r * 2);
-            $hitRx = $hitR / max(0.01, $this->aspectRatio);
-            $wrapper->markHasSeriesElements();
-            foreach ($points as $i => [$x, $y]) {
-                $p = $this->series->points[$i];
-                $id = "{$chartId}-pt-{$i}";
-                $tipText = $this->tooltip($p->label, $p->value);
-                $hasLink = $p->link !== null;
-                // Wrap visual marker + transparent hit target in a <g> so that
-                // CSS :hover/:focus-within on the group can highlight the visual
-                // ellipse even though the (larger) hit target intercepts events.
-                $group = Tag::make('g', ['class' => 'series-0']);
-                $group->append(Tag::make('ellipse', [
-                    'cx' => Tag::formatFloat($x),
-                    'cy' => Tag::formatFloat($y),
-                    'rx' => Tag::formatFloat($rx),
-                    'ry' => Tag::formatFloat($r),
-                    'fill' => $stroke,
-                ])->append(Tag::make('title')->append($tipText)));
-                // Transparent hit target — larger than the visual dot for easier hover/focus.
-                // When linked, the <a> carries id/tabindex; otherwise they live here.
-                $hitAttrs = [
-                    'id' => $hasLink ? null : $id,
-                    'cx' => Tag::formatFloat($x),
-                    'cy' => Tag::formatFloat($y),
-                    'rx' => Tag::formatFloat($hitRx),
-                    'ry' => Tag::formatFloat($hitR),
-                    'fill' => 'transparent',
-                    'tabindex' => $hasLink ? null : '0',
-                ];
-                $group->append(Tag::make('ellipse', $hitAttrs)->append(Tag::make('title')->append($tipText)));
-                $wrapper->add($hasLink ? $this->buildLink($p->link, $id, $group) : $group);
-                $wrapper->tooltip(new Tooltip(
-                    id: $id,
-                    text: Tag::escapeText($tipText),
-                    leftPct: $x / $viewport->width * 100,
-                    topPct: $y / $viewport->height * 100,
-                ));
-            }
+            $this->renderMarkers($wrapper, $series, $index, $points, $color, $strokeWidth, $viewport);
         }
+    }
 
-        if ($this->showAxes) {
-            $this->addLabels($wrapper, $xScale, $yScale);
+    /**
+     * @param list<array{0: float, 1: float}> $points
+     */
+    private function renderMarkers(
+        Wrapper $wrapper,
+        Series $series,
+        int $index,
+        array $points,
+        string $color,
+        float $strokeWidth,
+        Viewport $viewport,
+    ): void {
+        $chartId = $this->chartId();
+        $r = $strokeWidth * 0.6;
+        $rx = $r / max(0.01, $this->aspectRatio);
+        $hitR = max(4.0, $r * 2);
+        $hitRx = $hitR / max(0.01, $this->aspectRatio);
+        $wrapper->markHasSeriesElements();
+
+        foreach ($points as $i => [$x, $y]) {
+            $p = $series->points[$i];
+            $id = "{$chartId}-s{$index}-pt-{$i}";
+            $tipText = $this->tooltip($this->labelFor($series, $p->label), $p->value);
+            $hasLink = $p->link !== null;
+            // Wrap visual marker + transparent hit target in a <g> so that
+            // CSS :hover/:focus-within on the group can highlight the visual
+            // ellipse even though the (larger) hit target intercepts events.
+            $group = Tag::make('g', ['class' => "series-{$index}"]);
+            $group->append(Tag::make('ellipse', [
+                'cx' => Tag::formatFloat($x),
+                'cy' => Tag::formatFloat($y),
+                'rx' => Tag::formatFloat($rx),
+                'ry' => Tag::formatFloat($r),
+                'fill' => $color,
+            ])->append(Tag::make('title')->append($tipText)));
+            $hitAttrs = [
+                'id' => $hasLink ? null : $id,
+                'cx' => Tag::formatFloat($x),
+                'cy' => Tag::formatFloat($y),
+                'rx' => Tag::formatFloat($hitRx),
+                'ry' => Tag::formatFloat($hitR),
+                'fill' => 'transparent',
+                'tabindex' => $hasLink ? null : '0',
+            ];
+            $group->append(Tag::make('ellipse', $hitAttrs)->append(Tag::make('title')->append($tipText)));
+            $wrapper->add($hasLink ? $this->buildLink($p->link, $id, $group) : $group);
+            $wrapper->tooltip(new Tooltip(
+                id: $id,
+                text: Tag::escapeText($tipText),
+                leftPct: $x / $viewport->width * 100,
+                topPct: $y / $viewport->height * 100,
+            ));
         }
+    }
 
-        return $wrapper->render();
+    /**
+     * Per-series color: explicit Series->color wins, then `->stroke()` for
+     * series 0 (the chart-level shortcut), then the theme palette.
+     */
+    private function resolveColor(Series $series, int $index): string
+    {
+        if ($series->color !== null) {
+            return $series->color;
+        }
+        if ($index === 0 && $this->strokeColor !== null) {
+            return $this->strokeColor;
+        }
+        return $this->theme->colorAt($index);
+    }
+
+    /**
+     * Prefix tooltip with the series name when set so multi-series points
+     * can be told apart.
+     */
+    private function labelFor(Series $series, ?string $pointLabel): ?string
+    {
+        if ($series->name === '') {
+            return $pointLabel;
+        }
+        return $pointLabel === null || $pointLabel === ''
+            ? $series->name
+            : "{$series->name} — {$pointLabel}";
     }
 
     /**
@@ -300,8 +377,7 @@ class LineChart extends AbstractChart
             ));
         }
 
-        $labels = $this->series->labels();
-        foreach ($labels as $i => $label) {
+        foreach ($this->seriesCollection->commonLabels() as $i => $label) {
             if ($label === null || $label === '') {
                 continue;
             }

--- a/src/Data/Series.php
+++ b/src/Data/Series.php
@@ -4,17 +4,67 @@ declare(strict_types=1);
 
 namespace Noeka\Svgraph\Data;
 
+/**
+ * One data series. Carries optional metadata (`name`, `color`) so multi-series
+ * charts can label and theme each series independently.
+ *
+ * Aggregates (values/min/max/sum) are computed once at construction so the
+ * render path can read them without re-walking `points`.
+ */
 final readonly class Series implements \Countable
 {
     /** @var list<Point> */
     public array $points;
 
+    /** @var list<float> */
+    public array $values;
+
+    public float $min;
+    public float $max;
+    public float $sum;
+
     /**
      * @param list<Point> $points
      */
-    public function __construct(array $points)
-    {
+    public function __construct(
+        array $points,
+        public string $name = '',
+        public ?string $color = null,
+    ) {
         $this->points = $points;
+
+        $values = [];
+        $min = INF;
+        $max = -INF;
+        $sum = 0.0;
+        foreach ($points as $p) {
+            $v = $p->value;
+            $values[] = $v;
+            if ($v < $min) {
+                $min = $v;
+            }
+            if ($v > $max) {
+                $max = $v;
+            }
+            $sum += $v;
+        }
+        $this->values = $values;
+        $this->min = $values === [] ? 0.0 : $min;
+        $this->max = $values === [] ? 0.0 : $max;
+        $this->sum = $sum;
+    }
+
+    /**
+     * Normalise the input shapes accepted by Series::from() and attach a name
+     * and optional color. Convenience for fluent builders:
+     *
+     *   $chart->addSeries(Series::of('Revenue', $data, '#3b82f6'));
+     *
+     * @param iterable<mixed> $data
+     */
+    public static function of(string $name, iterable $data, ?string $color = null): self
+    {
+        return new self(self::normalise($data), $name, $color);
     }
 
     /**
@@ -32,6 +82,15 @@ final readonly class Series implements \Countable
      * @param iterable<mixed> $input
      */
     public static function from(iterable $input): self
+    {
+        return new self(self::normalise($input));
+    }
+
+    /**
+     * @param iterable<mixed> $input
+     * @return list<Point>
+     */
+    private static function normalise(iterable $input): array
     {
         $points = [];
         foreach ($input as $key => $value) {
@@ -57,7 +116,7 @@ final readonly class Series implements \Countable
             }
             $points[] = new Point($val, is_string($key) ? $key : null);
         }
-        return new self($points);
+        return $points;
     }
 
     private static function toFloat(mixed $v): float
@@ -73,6 +132,16 @@ final readonly class Series implements \Countable
         return is_scalar($v) ? (string) $v : null;
     }
 
+    public function withName(string $name): self
+    {
+        return new self($this->points, $name, $this->color);
+    }
+
+    public function withColor(?string $color): self
+    {
+        return new self($this->points, $this->name, $color);
+    }
+
     public function count(): int
     {
         return count($this->points);
@@ -85,25 +154,23 @@ final readonly class Series implements \Countable
 
     public function min(): float
     {
-        $values = array_map(static fn(Point $p) => $p->value, $this->points);
-        return $values !== [] ? min($values) : 0.0;
+        return $this->min;
     }
 
     public function max(): float
     {
-        $values = array_map(static fn(Point $p) => $p->value, $this->points);
-        return $values !== [] ? max($values) : 0.0;
+        return $this->max;
     }
 
     public function sum(): float
     {
-        return array_sum(array_map(static fn(Point $p) => $p->value, $this->points));
+        return $this->sum;
     }
 
     /** @return list<float> */
     public function values(): array
     {
-        return array_map(static fn(Point $p) => $p->value, $this->points);
+        return $this->values;
     }
 
     /** @return list<string|null> */

--- a/src/Data/SeriesCollection.php
+++ b/src/Data/SeriesCollection.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noeka\Svgraph\Data;
+
+/**
+ * Ordered list of Series. Lets multi-series charts share Y-scale calculations
+ * (combined min/max, stacked cumulative max) and pull a common label axis
+ * without each chart re-deriving the same numbers.
+ *
+ * Immutable: `with(Series)` returns a new collection.
+ */
+final readonly class SeriesCollection implements \Countable
+{
+    /** @var list<Series> */
+    public array $items;
+
+    /**
+     * @param list<Series> $items
+     */
+    public function __construct(array $items = [])
+    {
+        $this->items = $items;
+    }
+
+    public function with(Series $series): self
+    {
+        return new self([...$this->items, $series]);
+    }
+
+    public function count(): int
+    {
+        return count($this->items);
+    }
+
+    public function isEmpty(): bool
+    {
+        // A collection is empty for rendering when every series is empty.
+        if ($this->items === []) {
+            return true;
+        }
+        foreach ($this->items as $s) {
+            if (!$s->isEmpty()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Length of the longest series (number of x positions).
+     */
+    public function maxLength(): int
+    {
+        $max = 0;
+        foreach ($this->items as $s) {
+            $n = count($s);
+            if ($n > $max) {
+                $max = $n;
+            }
+        }
+        return $max;
+    }
+
+    /**
+     * Smallest value across every series, or 0 if all are empty.
+     */
+    public function valueMin(): float
+    {
+        $min = INF;
+        foreach ($this->items as $s) {
+            if ($s->isEmpty()) {
+                continue;
+            }
+            if ($s->min < $min) {
+                $min = $s->min;
+            }
+        }
+        return is_finite($min) ? $min : 0.0;
+    }
+
+    /**
+     * Largest value across every series, or 0 if all are empty.
+     */
+    public function valueMax(): float
+    {
+        $max = -INF;
+        foreach ($this->items as $s) {
+            if ($s->isEmpty()) {
+                continue;
+            }
+            if ($s->max > $max) {
+                $max = $s->max;
+            }
+        }
+        return is_finite($max) ? $max : 0.0;
+    }
+
+    /**
+     * Largest cumulative sum at any single x-position, treating only
+     * positive values as stacking upwards. Used to size the Y axis for
+     * stacked bar charts.
+     */
+    public function stackedMax(): float
+    {
+        $length = $this->maxLength();
+        if ($length === 0) {
+            return 0.0;
+        }
+        $max = 0.0;
+        for ($i = 0; $i < $length; $i++) {
+            $sum = 0.0;
+            foreach ($this->items as $s) {
+                $v = $s->values[$i] ?? 0.0;
+                if ($v > 0.0) {
+                    $sum += $v;
+                }
+            }
+            if ($sum > $max) {
+                $max = $sum;
+            }
+        }
+        return $max;
+    }
+
+    /**
+     * Smallest cumulative sum at any single x-position, treating only
+     * negative values as stacking downwards. Returns 0 when no negatives.
+     */
+    public function stackedMin(): float
+    {
+        $length = $this->maxLength();
+        if ($length === 0) {
+            return 0.0;
+        }
+        $min = 0.0;
+        for ($i = 0; $i < $length; $i++) {
+            $sum = 0.0;
+            foreach ($this->items as $s) {
+                $v = $s->values[$i] ?? 0.0;
+                if ($v < 0.0) {
+                    $sum += $v;
+                }
+            }
+            if ($sum < $min) {
+                $min = $sum;
+            }
+        }
+        return $min;
+    }
+
+    /**
+     * Pick a representative x-axis label list. Returns the labels of the
+     * longest series so a chart that omits labels on shorter series still
+     * shows them along the axis.
+     *
+     * @return list<string|null>
+     */
+    public function commonLabels(): array
+    {
+        $best = [];
+        $bestLen = -1;
+        foreach ($this->items as $s) {
+            if (!$s->hasLabels()) {
+                continue;
+            }
+            $len = count($s);
+            if ($len > $bestLen) {
+                $best = $s->labels();
+                $bestLen = $len;
+            }
+        }
+        return $best;
+    }
+
+    public function hasLabels(): bool
+    {
+        foreach ($this->items as $s) {
+            if ($s->hasLabels()) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/Svg/Tooltip.php
+++ b/src/Svg/Tooltip.php
@@ -17,7 +17,8 @@ final class Tooltip
 {
     /**
      * @param string $id      The `id` attribute value on the corresponding SVG element.
-     *                        Format: `svgraph-{chartId}-pt-{i}`.
+     *                        Format: `svgraph-{chartId}-s{j}-pt-{i}` for series-based charts,
+     *                        `svgraph-{chartId}-pt-{i}` for slice/progress charts.
      * @param string $text    Already-HTML-escaped tooltip text to display.
      * @param float  $leftPct Left anchor as a percentage of the wrapper width.
      * @param float  $topPct  Top anchor as a percentage of the wrapper height.

--- a/tests/Charts/AnimationTest.php
+++ b/tests/Charts/AnimationTest.php
@@ -120,7 +120,7 @@ final class AnimationTest extends TestCase
     public function test_line_animation_adds_line_path_class(): void
     {
         $svg = Chart::line([1, 2, 3])->animate()->render();
-        self::assertStringContainsString('class="svgraph-line-path"', $svg);
+        self::assertMatchesRegularExpression('/class="[^"]*svgraph-line-path[^"]*"/', $svg);
     }
 
     public function test_line_animation_targets_correct_variant_class(): void

--- a/tests/Charts/ChartRenderingTest.php
+++ b/tests/Charts/ChartRenderingTest.php
@@ -438,10 +438,10 @@ final class ChartRenderingTest extends TestCase
     {
         $svg = Chart::bar(['X' => 5])->render();
 
-        // Element IDs follow the format svgraph-{n}-pt-{i}.
-        self::assertMatchesRegularExpression('/id="svgraph-\d+-pt-0"/', $svg);
-        self::assertMatchesRegularExpression('/data-for="svgraph-\d+-pt-0"/', $svg);
-        self::assertMatchesRegularExpression('/#svgraph-\d+-pt-0:hover/', $svg);
+        // Element IDs follow the format svgraph-{n}-s{j}-pt-{i}.
+        self::assertMatchesRegularExpression('/id="svgraph-\d+-s0-pt-0"/', $svg);
+        self::assertMatchesRegularExpression('/data-for="svgraph-\d+-s0-pt-0"/', $svg);
+        self::assertMatchesRegularExpression('/#svgraph-\d+-s0-pt-0:hover/', $svg);
     }
 
     public function test_data_elements_have_tabindex(): void
@@ -555,7 +555,8 @@ final class ChartRenderingTest extends TestCase
     {
         $svg = Chart::line([10, 20, 30])->points()->render();
 
-        self::assertSame(3, substr_count($svg, 'class="series-0"'));
+        // 1 line path + 3 marker groups, all carrying series-0.
+        self::assertSame(4, substr_count($svg, 'class="series-0"'));
         // Ellipses must be nested inside <g> elements.
         self::assertMatchesRegularExpression('/<g class="series-0">.*<ellipse/s', $svg);
     }
@@ -655,9 +656,9 @@ final class ChartRenderingTest extends TestCase
         ])->render();
 
         // Linked: ID on <a>, no tabindex on rect.
-        self::assertMatchesRegularExpression('/<a[^>]+id="svgraph-\d+-pt-0"/', $svg);
+        self::assertMatchesRegularExpression('/<a[^>]+id="svgraph-\d+-s0-pt-0"/', $svg);
         // Non-linked: ID on rect itself.
-        self::assertMatchesRegularExpression('/<rect[^>]+id="svgraph-\d+-pt-1"/', $svg);
+        self::assertMatchesRegularExpression('/<rect[^>]+id="svgraph-\d+-s0-pt-1"/', $svg);
     }
 
     public function test_bar_linked_anchor_with_blank_target_gets_noopener_rel(): void

--- a/tests/Charts/MultiSeriesTest.php
+++ b/tests/Charts/MultiSeriesTest.php
@@ -1,0 +1,422 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noeka\Svgraph\Tests\Charts;
+
+use Noeka\Svgraph\Chart;
+use Noeka\Svgraph\Data\Series;
+use PHPUnit\Framework\TestCase;
+
+final class MultiSeriesTest extends TestCase
+{
+    // ── Series metadata ────────────────────────────────────────────────────────
+
+    public function test_series_of_attaches_name_and_color(): void
+    {
+        $s = Series::of('Revenue', [1, 2, 3], '#3b82f6');
+        self::assertSame('Revenue', $s->name);
+        self::assertSame('#3b82f6', $s->color);
+        self::assertSame([1.0, 2.0, 3.0], $s->values);
+    }
+
+    public function test_series_of_color_optional(): void
+    {
+        $s = Series::of('Costs', [10, 20]);
+        self::assertSame('Costs', $s->name);
+        self::assertNull($s->color);
+    }
+
+    public function test_series_with_name_returns_clone(): void
+    {
+        $s = Series::from([1, 2, 3])->withName('Foo');
+        self::assertSame('Foo', $s->name);
+    }
+
+    public function test_series_with_color_returns_clone(): void
+    {
+        $s = Series::from([1, 2, 3])->withColor('#abcdef');
+        self::assertSame('#abcdef', $s->color);
+    }
+
+    // ── LineChart ──────────────────────────────────────────────────────────────
+
+    public function test_line_chart_renders_multiple_polylines(): void
+    {
+        $svg = Chart::line([10, 20, 30])
+            ->addSeries(Series::of('B', [5, 15, 25]))
+            ->render();
+
+        // One path per series.
+        self::assertSame(2, substr_count($svg, '<path '));
+        self::assertStringContainsString('class="series-0"', $svg);
+        self::assertStringContainsString('class="series-1"', $svg);
+    }
+
+    public function test_line_chart_per_series_color_from_palette(): void
+    {
+        $svg = Chart::line([10, 20, 30])
+            ->addSeries(Series::of('B', [5, 15, 25]))
+            ->render();
+
+        // Default palette: series 0 → #3b82f6, series 1 → #10b981.
+        self::assertStringContainsString('stroke="#3b82f6"', $svg);
+        self::assertStringContainsString('stroke="#10b981"', $svg);
+    }
+
+    public function test_line_chart_explicit_series_color_wins_over_palette(): void
+    {
+        $svg = Chart::line([1, 2, 3])
+            ->addSeries(Series::of('B', [4, 5, 6], '#ff00ff'))
+            ->render();
+
+        self::assertStringContainsString('stroke="#ff00ff"', $svg);
+    }
+
+    public function test_line_chart_y_scale_extends_to_cover_all_series(): void
+    {
+        // Series 1's max (100) is far above series 0's max (3); the chart
+        // must scale its Y-axis to fit both. Without a combined scale, the
+        // 100-value line would render off-canvas.
+        $svg = Chart::line([1, 2, 3])
+            ->addSeries(Series::of('Big', [50, 75, 100]))
+            ->axes()
+            ->render();
+
+        // 100 should appear in the y-axis ticks.
+        self::assertStringContainsString('100', $svg);
+    }
+
+    public function test_line_chart_markers_per_series(): void
+    {
+        $svg = Chart::line([10, 20])
+            ->addSeries(Series::of('B', [30, 40]))
+            ->points()
+            ->render();
+
+        // 2 series × 2 points × 2 ellipses (visual + hit) = 8 ellipses.
+        self::assertSame(8, substr_count($svg, '<ellipse '));
+        // Marker groups carry the series class.
+        self::assertMatchesRegularExpression('/<g class="series-0">/', $svg);
+        self::assertMatchesRegularExpression('/<g class="series-1">/', $svg);
+    }
+
+    public function test_line_chart_marker_id_includes_series_index(): void
+    {
+        $svg = Chart::line([10, 20])
+            ->addSeries(Series::of('B', [30, 40]))
+            ->points()
+            ->render();
+
+        // Series 0, point 0 and series 1, point 1 must both have unique IDs.
+        self::assertMatchesRegularExpression('/id="svgraph-\d+-s0-pt-0"/', $svg);
+        self::assertMatchesRegularExpression('/id="svgraph-\d+-s1-pt-1"/', $svg);
+    }
+
+    public function test_line_multi_series_tooltip_includes_series_name(): void
+    {
+        $svg = Chart::line([['Mon', 10]])
+            ->addSeries(Series::of('Costs', [['Mon', 5]]))
+            ->points()
+            ->render();
+
+        self::assertStringContainsString('<title>Costs — Mon: 5</title>', $svg);
+    }
+
+    public function test_line_chart_data_resets_to_single_series(): void
+    {
+        // Calling data() after addSeries() should drop everything and
+        // start fresh — preserves builder ergonomics.
+        $svg = Chart::line([1, 2, 3])
+            ->addSeries(Series::of('B', [4, 5, 6]))
+            ->data([10, 20, 30])
+            ->render();
+
+        self::assertSame(1, substr_count($svg, '<path '));
+    }
+
+    public function test_line_chart_handles_series_of_different_lengths(): void
+    {
+        // 3-point series and 5-point series should both render against the
+        // same x-axis; the longer series determines x extent.
+        $svg = Chart::line([1, 2, 3])
+            ->addSeries(Series::of('B', [10, 20, 30, 40, 50]))
+            ->render();
+
+        self::assertSame(2, substr_count($svg, '<path '));
+    }
+
+    // ── BarChart: grouped ─────────────────────────────────────────────────────
+
+    public function test_bar_grouped_renders_one_rect_per_series_per_slot(): void
+    {
+        $svg = Chart::bar(['Q1' => 10, 'Q2' => 20])
+            ->addSeries(Series::of('Costs', ['Q1' => 5, 'Q2' => 8]))
+            ->grouped()
+            ->render();
+
+        // 2 slots × 2 series = 4 rects.
+        self::assertSame(4, substr_count($svg, '<rect '));
+    }
+
+    public function test_bar_grouped_assigns_per_series_class(): void
+    {
+        $svg = Chart::bar(['A' => 1, 'B' => 2])
+            ->addSeries(Series::of('Costs', ['A' => 3, 'B' => 4]))
+            ->grouped()
+            ->render();
+
+        self::assertSame(2, substr_count($svg, 'class="series-0"'));
+        self::assertSame(2, substr_count($svg, 'class="series-1"'));
+    }
+
+    public function test_bar_multi_series_defaults_to_grouped(): void
+    {
+        $defaulted = Chart::bar(['A' => 1, 'B' => 2])
+            ->addSeries(Series::of('Costs', ['A' => 3, 'B' => 4]))
+            ->render();
+
+        $explicit = Chart::bar(['A' => 1, 'B' => 2])
+            ->addSeries(Series::of('Costs', ['A' => 3, 'B' => 4]))
+            ->grouped()
+            ->render();
+
+        // Each render uses a new auto-incrementing chart ID; normalise so
+        // we're comparing layout, not identity.
+        $normalise = static fn(string $svg): string => preg_replace('/svgraph-\d+/', 'svgraph-N', $svg) ?? '';
+        self::assertSame($normalise($defaulted), $normalise($explicit));
+    }
+
+    public function test_bar_grouped_y_scale_extends_to_cover_all_series(): void
+    {
+        $svg = Chart::bar(['A' => 1, 'B' => 2])
+            ->addSeries(Series::of('Big', ['A' => 90, 'B' => 100]))
+            ->grouped()
+            ->axes()
+            ->render();
+
+        self::assertStringContainsString('100', $svg);
+    }
+
+    public function test_bar_grouped_per_series_color_from_palette(): void
+    {
+        $svg = Chart::bar(['A' => 1, 'B' => 2])
+            ->addSeries(Series::of('Two', ['A' => 3, 'B' => 4]))
+            ->grouped()
+            ->render();
+
+        // Default palette: series 0 → #3b82f6, series 1 → #10b981.
+        self::assertSame(2, substr_count($svg, 'fill="#3b82f6"'));
+        self::assertSame(2, substr_count($svg, 'fill="#10b981"'));
+    }
+
+    public function test_bar_grouped_explicit_series_color_wins(): void
+    {
+        $svg = Chart::bar(['A' => 1, 'B' => 2])
+            ->addSeries(Series::of('Two', ['A' => 3, 'B' => 4], '#abcdef'))
+            ->grouped()
+            ->render();
+
+        self::assertSame(2, substr_count($svg, 'fill="#abcdef"'));
+    }
+
+    public function test_bar_grouped_horizontal_renders_rects(): void
+    {
+        $svg = Chart::bar(['A' => 1, 'B' => 2])
+            ->addSeries(Series::of('Two', ['A' => 3, 'B' => 4]))
+            ->grouped()
+            ->horizontal()
+            ->render();
+
+        self::assertSame(4, substr_count($svg, '<rect '));
+    }
+
+    public function test_bar_grouped_bars_are_narrower_than_single(): void
+    {
+        // Two side-by-side bars must be narrower than one full-slot bar.
+        $single = Chart::bar(['A' => 1, 'B' => 2])->render();
+        $grouped = Chart::bar(['A' => 1, 'B' => 2])
+            ->addSeries(Series::of('Two', ['A' => 3, 'B' => 4]))
+            ->grouped()
+            ->render();
+
+        self::assertGreaterThan(
+            $this->firstRectWidth($grouped),
+            $this->firstRectWidth($single),
+        );
+    }
+
+    private function firstRectWidth(string $svg): float
+    {
+        if (preg_match('/<rect [^>]*width="([0-9.]+)"/', $svg, $match) !== 1) {
+            self::fail('No rect width found in SVG.');
+        }
+        return (float) $match[1];
+    }
+
+    // ── BarChart: stacked ─────────────────────────────────────────────────────
+
+    public function test_bar_stacked_renders_one_rect_per_value(): void
+    {
+        $svg = Chart::bar(['A' => 10, 'B' => 20])
+            ->addSeries(Series::of('Two', ['A' => 5, 'B' => 8]))
+            ->stacked()
+            ->render();
+
+        self::assertSame(4, substr_count($svg, '<rect '));
+    }
+
+    public function test_bar_stacked_y_max_uses_cumulative_sum(): void
+    {
+        // Series A max = 10, Series B max = 30. Single max would be 30,
+        // but stacked must extend to 10 + 30 = 40 (the column total).
+        $svg = Chart::bar(['X' => 10])
+            ->addSeries(Series::of('B', ['X' => 30]))
+            ->stacked()
+            ->axes()
+            ->render();
+
+        // 40 should appear in the y-axis ticks.
+        self::assertStringContainsString('40', $svg);
+    }
+
+    public function test_bar_stacked_segments_dont_overlap(): void
+    {
+        // For column "X" with A=10 and B=20 stacked, we expect:
+        //   Series A segment: y=baseline-10..baseline (height = 10 in Y units)
+        //   Series B segment: y=baseline-30..baseline-10 (sits on top of A)
+        // The two rects must have different y values.
+        $svg = Chart::bar(['X' => 10])
+            ->addSeries(Series::of('B', ['X' => 20]))
+            ->stacked()
+            ->render();
+
+        preg_match_all('/<rect [^>]*y="([0-9.]+)"/', $svg, $matches);
+        $ys = array_unique($matches[1]);
+        // Two distinct y positions for the two stacked segments.
+        self::assertCount(2, $ys);
+    }
+
+    public function test_bar_stacked_horizontal_uses_cumulative_sum(): void
+    {
+        $svg = Chart::bar(['X' => 10])
+            ->addSeries(Series::of('B', ['X' => 30]))
+            ->stacked()
+            ->horizontal()
+            ->axes()
+            ->render();
+
+        self::assertStringContainsString('40', $svg);
+    }
+
+    public function test_bar_stacked_assigns_per_series_class(): void
+    {
+        $svg = Chart::bar(['A' => 1, 'B' => 2])
+            ->addSeries(Series::of('Two', ['A' => 3, 'B' => 4]))
+            ->stacked()
+            ->render();
+
+        self::assertSame(2, substr_count($svg, 'class="series-0"'));
+        self::assertSame(2, substr_count($svg, 'class="series-1"'));
+    }
+
+    public function test_bar_stacked_skips_zero_values(): void
+    {
+        // A zero value contributes nothing to the stack and is not drawn.
+        $svg = Chart::bar(['A' => 10, 'B' => 0])
+            ->addSeries(Series::of('Two', ['A' => 5, 'B' => 5]))
+            ->stacked()
+            ->render();
+
+        // 4 expected segments minus 1 zero = 3.
+        self::assertSame(3, substr_count($svg, '<rect '));
+    }
+
+    public function test_bar_stacked_negative_values_extend_y_axis_below_zero(): void
+    {
+        // Two negatives stacked downward: cumulative minimum is the sum.
+        $svg = Chart::bar(['X' => -10])
+            ->addSeries(Series::of('B', ['X' => -20]))
+            ->stacked()
+            ->axes()
+            ->render();
+
+        // -30 should appear as a tick label on the y axis.
+        self::assertStringContainsString('-30', $svg);
+    }
+
+    public function test_bar_stacked_horizontal_negative_values_extend_x_axis(): void
+    {
+        $svg = Chart::bar(['X' => -10])
+            ->addSeries(Series::of('B', ['X' => -20]))
+            ->stacked()
+            ->horizontal()
+            ->axes()
+            ->render();
+
+        self::assertStringContainsString('-30', $svg);
+    }
+
+    public function test_bar_stacked_three_series_y_max_is_total(): void
+    {
+        $svg = Chart::bar(['X' => 10])
+            ->addSeries(Series::of('B', ['X' => 20]))
+            ->addSeries(Series::of('C', ['X' => 30]))
+            ->stacked()
+            ->axes()
+            ->render();
+
+        // 10 + 20 + 30 = 60.
+        self::assertStringContainsString('60', $svg);
+    }
+
+    public function test_bar_grouped_then_stacked_uses_last_choice(): void
+    {
+        $svg = Chart::bar(['A' => 10, 'B' => 20])
+            ->addSeries(Series::of('Two', ['A' => 5, 'B' => 5]))
+            ->grouped()
+            ->stacked()
+            ->render();
+
+        // Stacked produces 4 rects in 2 distinct y-positions per slot.
+        preg_match_all('/<rect [^>]*y="([0-9.]+)"/', $svg, $matches);
+        self::assertGreaterThan(2, count(array_unique($matches[1])));
+    }
+
+    // ── BarChart: backward-compat single-series ──────────────────────────────
+
+    public function test_bar_single_series_unchanged_layout(): void
+    {
+        // Single-series rendering must continue to occupy the full slot width.
+        $svg = Chart::bar(['A' => 10, 'B' => 20])->render();
+        self::assertSame(2, substr_count($svg, '<rect '));
+    }
+
+    public function test_bar_single_series_id_format_includes_series_index(): void
+    {
+        $svg = Chart::bar(['A' => 1])->render();
+        self::assertMatchesRegularExpression('/id="svgraph-\d+-s0-pt-0"/', $svg);
+    }
+
+    // ── Tooltips with series name ─────────────────────────────────────────────
+
+    public function test_bar_grouped_tooltip_includes_series_name(): void
+    {
+        $svg = Chart::bar(['Q1' => 10])
+            ->addSeries(Series::of('Costs', ['Q1' => 5]))
+            ->grouped()
+            ->render();
+
+        self::assertStringContainsString('<title>Costs — Q1: 5</title>', $svg);
+    }
+
+    public function test_bar_stacked_tooltip_includes_series_name(): void
+    {
+        $svg = Chart::bar(['Q1' => 10])
+            ->addSeries(Series::of('Costs', ['Q1' => 5]))
+            ->stacked()
+            ->render();
+
+        self::assertStringContainsString('<title>Costs — Q1: 5</title>', $svg);
+    }
+}


### PR DESCRIPTION
- Series gains optional name/color metadata and a Series::of() factory;
  aggregates (values/min/max/sum) are precomputed at construction.
- New SeriesCollection holds an ordered list of Series and exposes the
  cross-series aggregates charts need (combined min/max, stackedMin/Max,
  commonLabels) so each chart doesn't re-derive them.
- LineChart renders N polylines with per-series colour and .series-{N}
  class; markers use a unique svgraph-{n}-s{j}-pt-{i} ID format.
- BarChart adds ->grouped() and ->stacked() modes. Grouped is the default
  for multi-series; stacked extends the y-axis to the cumulative max
  (positive) and min (negative) sums.
- Multi-series tooltips prefix with the series name.
- Single-series rendering goes through the same grouped path; the rainbow
  palette feature stays as a per-bar tweak.
- Drop the legacy single-series-only ID format; everything now uses the
  s{j}-pt-{i} suffix.