### PR TITLE
fix: correct animation bugs and remove pie hover pop effect

### DIFF
--- a/src/Charts/LineChart.php
+++ b/src/Charts/LineChart.php
@@ -253,6 +253,8 @@ class LineChart extends AbstractChart
         if ($this->animated) {
             $lineAttrs['class'] = "series-{$index} svgraph-line-path";
             $lineAttrs['pathLength'] = '1';
+            $lineAttrs['stroke-dasharray'] = '1';
+            $lineAttrs['stroke-dashoffset'] = '1';
         }
         $wrapper->add(Tag::void('path', $lineAttrs));
 

--- a/src/Charts/PieChart.php
+++ b/src/Charts/PieChart.php
@@ -166,12 +166,8 @@ class PieChart extends AbstractChart
             $d = Path::arc($cx, $cy, $outerRadius, $innerRadius, $start, $end);
             $id = "{$chartId}-pt-{$i}";
             $tipText = $this->tooltip($slice->label, $value);
-            $midAngle = ($start + $end) / 2;
-            $popX = round(sin($midAngle), 4);
-            $popY = round(-cos($midAngle), 4);
             $path = Tag::make('path', [
                 'class' => "series-{$i}",
-                'style' => "--pop-x:{$popX};--pop-y:{$popY};",
                 'd' => $d,
                 'fill' => $color,
             ])->append(Tag::make('title')->append($tipText));
@@ -236,7 +232,7 @@ class PieChart extends AbstractChart
             $tipText = $this->tooltip($only->label, $only->value);
             $circ = Tag::formatFloat($circumference);
             $off = Tag::formatFloat($circumference / 4.0 - ($this->startAngle / 360.0) * $circumference);
-            // Full circle: dasharray = circ 0 (entire circumference is the dash).
+            // Full circle: initial dasharray = 0 circ (hidden); animation sweeps to circ 0.
             $circle = Tag::make('circle', [
                 'class' => 'series-0',
                 'cx' => Tag::formatFloat($cx),
@@ -245,9 +241,9 @@ class PieChart extends AbstractChart
                 'fill' => 'none',
                 'stroke' => $color,
                 'stroke-width' => Tag::formatFloat($strokeWidth),
-                'stroke-dasharray' => "{$circ} 0",
+                'stroke-dasharray' => "0 {$circ}",
                 'stroke-dashoffset' => $off,
-                'style' => "--pop-x:0;--pop-y:0;--svgraph-pie-off:{$off};--svgraph-pie-len:{$circ};--svgraph-pie-circ:{$circ};",
+                'style' => "--svgraph-pie-off:{$off};--svgraph-pie-len:{$circ};--svgraph-pie-circ:{$circ};",
             ])->append(Tag::make('title')->append($tipText));
             $wrapper->add($this->buildLink($only->link, $id, $circle));
             $wrapper->tooltip(new Tooltip(
@@ -285,13 +281,10 @@ class PieChart extends AbstractChart
 
             $dashOffset = $circumference / 4.0 - $startOffsetArc - $cumulativeArc - $halfGapArc;
             $arcLen = Tag::formatFloat($visibleArc);
-            $gap = Tag::formatFloat(max(0.0, $circumference - $visibleArc));
             $off = Tag::formatFloat($dashOffset);
             $delay = round($i * 0.08, 3);
 
             $midAngle = $angle + $sweepAngle / 2.0;
-            $popX = round(sin($midAngle), 4);
-            $popY = round(-cos($midAngle), 4);
 
             $color = $slice->color ?? $this->theme->colorAt($i);
             $id = "{$chartId}-pt-{$i}";
@@ -305,9 +298,9 @@ class PieChart extends AbstractChart
                 'fill' => 'none',
                 'stroke' => $color,
                 'stroke-width' => Tag::formatFloat($strokeWidth),
-                'stroke-dasharray' => "{$arcLen} {$gap}",
+                'stroke-dasharray' => "0 {$circ}",
                 'stroke-dashoffset' => $off,
-                'style' => "--pop-x:{$popX};--pop-y:{$popY};--svgraph-pie-off:{$off};--svgraph-pie-len:{$arcLen};--svgraph-pie-circ:{$circ};animation-delay:{$delay}s;",
+                'style' => "--svgraph-pie-off:{$off};--svgraph-pie-len:{$arcLen};--svgraph-pie-circ:{$circ};animation-delay:{$delay}s;",
             ])->append(Tag::make('title')->append($tipText));
 
             $wrapper->add($this->buildLink($slice->link, $id, $circle));

--- a/src/Svg/Wrapper.php
+++ b/src/Svg/Wrapper.php
@@ -253,37 +253,6 @@ final class Wrapper
             . '.svgraph g[class^="series-"]:focus-within>ellipse:first-child{'
             . 'filter:brightness(var(--svgraph-hover-brightness,1.2));}';
 
-        // Pie/donut slice pop: per-slice --pop-x/--pop-y unit vectors are set as
-        // inline CSS custom properties by the PHP renderer.
-        $piePop = '.svgraph--pie path[class^="series-"]:hover,'
-            . '.svgraph--pie path[class^="series-"]:focus-visible,'
-            . '.svgraph--pie circle[class^="series-"]:hover,'
-            . '.svgraph--pie circle[class^="series-"]:focus-visible,'
-            . '.svgraph--donut path[class^="series-"]:hover,'
-            . '.svgraph--donut path[class^="series-"]:focus-visible,'
-            . '.svgraph--donut circle[class^="series-"]:hover,'
-            . '.svgraph--donut circle[class^="series-"]:focus-visible{'
-            . 'transform:translate('
-            . 'calc(var(--svgraph-pie-pop-distance,3px)*var(--pop-x,0)),'
-            . 'calc(var(--svgraph-pie-pop-distance,3px)*var(--pop-y,0))'
-            . ');}';
-
-        // Under reduced motion: suppress the translate pop but keep colour change.
-        $reducedMotion = '@media (prefers-reduced-motion:reduce){'
-            . '.svgraph--pie path[class^="series-"]:hover,'
-            . '.svgraph--pie path[class^="series-"]:focus-visible,'
-            . '.svgraph--pie a.svgraph-linked:focus-visible path[class^="series-"],'
-            . '.svgraph--pie circle[class^="series-"]:hover,'
-            . '.svgraph--pie circle[class^="series-"]:focus-visible,'
-            . '.svgraph--pie a.svgraph-linked:focus-visible circle[class^="series-"],'
-            . '.svgraph--donut path[class^="series-"]:hover,'
-            . '.svgraph--donut path[class^="series-"]:focus-visible,'
-            . '.svgraph--donut a.svgraph-linked:focus-visible path[class^="series-"],'
-            . '.svgraph--donut circle[class^="series-"]:hover,'
-            . '.svgraph--donut circle[class^="series-"]:focus-visible,'
-            . '.svgraph--donut a.svgraph-linked:focus-visible circle[class^="series-"]{'
-            . 'transform:none;}}';
-
         // Linked elements: cursor + keyboard-focus highlight rules.
         // :hover on the inner element is already handled by the rules above
         // (the inner rect/path/etc. is still directly under the pointer).
@@ -301,17 +270,9 @@ final class Wrapper
             . 'filter:brightness(var(--svgraph-hover-brightness,1.2));'
             . 'outline:none;}'
             . '.svgraph a.svgraph-linked:focus-visible g[class^="series-"]>ellipse:first-child{'
-            . 'filter:brightness(var(--svgraph-hover-brightness,1.2));}'
-            . '.svgraph--pie a.svgraph-linked:focus-visible path[class^="series-"],'
-            . '.svgraph--pie a.svgraph-linked:focus-visible circle[class^="series-"],'
-            . '.svgraph--donut a.svgraph-linked:focus-visible path[class^="series-"],'
-            . '.svgraph--donut a.svgraph-linked:focus-visible circle[class^="series-"]{'
-            . 'transform:translate('
-            . 'calc(var(--svgraph-pie-pop-distance,3px)*var(--pop-x,0)),'
-            . 'calc(var(--svgraph-pie-pop-distance,3px)*var(--pop-y,0))'
-            . ');}';
+            . 'filter:brightness(var(--svgraph-hover-brightness,1.2));}';
 
-        return $direct . $lineMarkers . $piePop . $reducedMotion . $linked;
+        return $direct . $lineMarkers . $linked;
     }
 
     private function buildTooltipStyle(): string
@@ -373,10 +334,11 @@ final class Wrapper
         $css = '';
 
         // Line / sparkline: stroke-dasharray draw-on using pathLength="1" normalisation.
+        // stroke-dasharray="1" and stroke-dashoffset="1" are set as HTML attributes
+        // (where pathLength normalization is reliable); CSS only drives the offset.
         if ($this->variantClass === 'line' || $this->variantClass === 'sparkline') {
             $css .= '@keyframes svgraph-draw-line{from{stroke-dashoffset:1}to{stroke-dashoffset:0}}'
                 . '.svgraph--' . $this->variantClass . ' .svgraph-line-path{'
-                . 'stroke-dasharray:1;'
                 . 'animation:svgraph-draw-line ' . $dur . ' ' . $ease . ' both;}';
         }
 
@@ -415,6 +377,24 @@ final class Wrapper
                 . 'animation-delay:var(--svgraph-pie-delay,0ms);}';
         }
 
-        return '@media (prefers-reduced-motion:no-preference){' . $css . '}';
+        $reduceCss = '';
+
+        // Reduced-motion fallbacks: show the final state without animation for
+        // users who request reduced motion but whose page still calls ->animate().
+        if ($this->variantClass === 'line' || $this->variantClass === 'sparkline') {
+            // stroke-dashoffset="1" is set in the HTML; override it to 0 here.
+            $reduceCss .= '.svgraph--' . $this->variantClass . ' .svgraph-line-path{stroke-dashoffset:0;}';
+        }
+        if ($this->variantClass === 'pie' || $this->variantClass === 'donut') {
+            // stroke-dasharray="0 circ" is the initial hidden state; show the final arc.
+            $reduceCss .= '.svgraph--' . $this->variantClass . ' circle[class^="series-"]{'
+                . 'stroke-dasharray:var(--svgraph-pie-len) calc(var(--svgraph-pie-circ) - var(--svgraph-pie-len));}';
+        }
+
+        $result = '@media (prefers-reduced-motion:no-preference){' . $css . '}';
+        if ($reduceCss !== '') {
+            $result .= '@media (prefers-reduced-motion:reduce){' . $reduceCss . '}';
+        }
+        return $result;
     }
 }

--- a/tests/Charts/AnimationTest.php
+++ b/tests/Charts/AnimationTest.php
@@ -233,22 +233,18 @@ final class AnimationTest extends TestCase
         self::assertGreaterThanOrEqual(3, substr_count($svg, '<circle '));
     }
 
-    public function test_pie_animation_circles_have_stroke_dasharray(): void
+    public function test_pie_animation_circles_start_hidden(): void
     {
+        // Initial stroke-dasharray must be "0 {circumference}" so slices are invisible
+        // before the animation runs, preventing a flash of the final state.
         $svg = Chart::pie(['A' => 50, 'B' => 50])->animate()->render();
-        self::assertMatchesRegularExpression('/stroke-dasharray="[0-9.]+ [0-9.]+"/', $svg);
+        self::assertMatchesRegularExpression('/stroke-dasharray="0 [0-9.]+"/', $svg);
     }
 
     public function test_pie_animation_circles_have_stroke_dashoffset(): void
     {
         $svg = Chart::pie(['A' => 50, 'B' => 50])->animate()->render();
         self::assertStringContainsString('stroke-dashoffset=', $svg);
-    }
-
-    public function test_pie_animation_circles_have_pop_vectors(): void
-    {
-        $svg = Chart::pie(['A' => 50, 'B' => 50])->animate()->render();
-        self::assertMatchesRegularExpression('/style="--pop-x:[^"]+--pop-y:[^"]+"/', $svg);
     }
 
     public function test_pie_animation_circles_have_pie_custom_properties(): void
@@ -318,21 +314,24 @@ final class AnimationTest extends TestCase
         self::assertStringContainsString('svgraph-pie-sweep', $svg);
     }
 
-    // ── Hover pop still works on animated pie circles ─────────────────────────
+    // ── Reduced-motion final-state fallbacks ─────────────────────────────────
 
-    public function test_hover_pop_css_includes_circle_selectors_for_pie(): void
+    public function test_animated_line_emits_reduced_motion_final_state(): void
     {
-        // Even non-animated pies get the circle selector in hover CSS (for
-        // the single-slice case and future animated usage).
-        $svg = Chart::pie(['A' => 1, 'B' => 1])->render();
-        self::assertStringContainsString('.svgraph--pie circle[class^="series-"]:hover', $svg);
+        $svg = Chart::line([1, 2, 3])->animate()->render();
+        // Reduced-motion users must see the fully-drawn line (dashoffset:0).
+        self::assertMatchesRegularExpression(
+            '/prefers-reduced-motion:reduce\)[^<]*svgraph-line-path[^<]*stroke-dashoffset:0/',
+            $svg,
+        );
     }
 
-    public function test_reduced_motion_suppresses_pop_on_pie_circles(): void
+    public function test_animated_pie_emits_reduced_motion_final_state(): void
     {
-        $svg = Chart::pie(['A' => 1, 'B' => 1])->render();
+        $svg = Chart::pie(['A' => 1, 'B' => 1])->animate()->render();
+        // Reduced-motion users must see the final arc (not the hidden initial state).
         self::assertMatchesRegularExpression(
-            '/prefers-reduced-motion:reduce\).*circle\[class\^="series-"\].*transform:none/s',
+            '/prefers-reduced-motion:reduce\)[^<]*svgraph-pie-len/',
             $svg,
         );
     }

--- a/tests/Charts/ChartRenderingTest.php
+++ b/tests/Charts/ChartRenderingTest.php
@@ -543,14 +543,6 @@ final class ChartRenderingTest extends TestCase
         self::assertStringContainsString('class="series-0"', $svg);
     }
 
-    public function test_pie_slices_have_pop_vector_inline_vars(): void
-    {
-        $svg = Chart::pie(['A' => 1, 'B' => 1])->render();
-
-        // Each slice path must carry --pop-x and --pop-y in its style attribute.
-        self::assertMatchesRegularExpression('/style="--pop-x:[^"]+--pop-y:[^"]+"/', $svg);
-    }
-
     public function test_line_marker_groups_have_series_class(): void
     {
         $svg = Chart::line([10, 20, 30])->points()->render();
@@ -569,24 +561,6 @@ final class ChartRenderingTest extends TestCase
         self::assertStringContainsString('--svgraph-hover-stroke-width', $svg);
     }
 
-    public function test_pie_chart_emits_pop_style_rules(): void
-    {
-        $svg = Chart::pie(['A' => 1, 'B' => 1])->render();
-
-        self::assertStringContainsString('--svgraph-pie-pop-distance', $svg);
-        self::assertStringContainsString('--pop-x', $svg);
-        self::assertStringContainsString('--pop-y', $svg);
-    }
-
-    public function test_hover_style_honours_prefers_reduced_motion(): void
-    {
-        $svg = Chart::pie(['A' => 1, 'B' => 1])->render();
-
-        self::assertStringContainsString('prefers-reduced-motion', $svg);
-        // The reduced-motion block must suppress the transform.
-        self::assertMatchesRegularExpression('/prefers-reduced-motion[^}]+\{[^}]*transform:none/', $svg);
-    }
-
     public function test_hover_css_custom_properties_on_wrapper(): void
     {
         $svg = Chart::bar(['A' => 1])->render();
@@ -603,7 +577,7 @@ final class ChartRenderingTest extends TestCase
 
         self::assertStringContainsString('--svgraph-hover-brightness:1.5', $svg);
         self::assertStringContainsString('--svgraph-hover-stroke-width:2', $svg);
-        self::assertStringContainsString('--svgraph-pie-pop-distance:5px', $svg);
+        self::assertStringContainsString('--svgraph-pie-pop-distance:5px', $svg); // custom property still emitted on wrapper
     }
 
     public function test_line_without_points_emits_no_hover_style(): void
@@ -621,13 +595,12 @@ final class ChartRenderingTest extends TestCase
         self::assertSame(2, substr_count($svg, 'class="series-0"'));
     }
 
-    public function test_donut_slices_have_series_class_and_pop_vars(): void
+    public function test_donut_slices_have_series_class(): void
     {
         $svg = Chart::donut(['X' => 3, 'Y' => 1])->render();
 
         self::assertStringContainsString('class="series-0"', $svg);
         self::assertStringContainsString('class="series-1"', $svg);
-        self::assertStringContainsString('--pop-x:', $svg);
     }
 
     // ── Click-through link tests (issue #7) ──────────────────────────────────


### PR DESCRIPTION
- Line chart: stroke-dasharray:1 in CSS was unreliable because SVG
  pathLength normalization is not always respected for CSS-applied
  dash arrays. Move stroke-dasharray="1" and stroke-dashoffset="1"
  to HTML attributes where pathLength="1" normalization is guaranteed.
  CSS now only animates stroke-dashoffset, eliminating the dashed
  appearance.

- Pie/donut: initial stroke-dasharray attribute was set to the final
  arc value, causing a visible flash before the CSS animation's
  fill-mode:backwards could hide it. Changed initial attribute to
  "0 {circumference}" (hidden) so there is nothing to flash.

- Pie/donut: removed the translate-on-hover pop effect (--pop-x,
  --pop-y transform) from slice paths and circles. Also cleaned up
  the per-element custom properties and the reduced-motion suppression
  rule that existed solely for this effect.

- Added @media (prefers-reduced-motion:reduce) fallback rules in
  buildAnimationStyle() for both line and pie/donut, so users who
  prefer reduced motion still see the final static chart state when
  ->animate() is called.

https://claude.ai/code/session_01HYe1kbQLjQQrNUAKfLLQzX