### PR TITLE
feat: CSS-only toggle legend for line and bar charts (issue #10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,30 @@ Chart::line(['Jan' => 12, 'Feb' => 27, 'Mar' => 18])
 For bar charts, `->grouped()` and `->stacked()` pick how series share
 each x-tick. See [bar chart docs](docs/charts/bar.md#multi-series).
 
+## Legend (toggle series visibility)
+
+```php
+Chart::line(['Jan' => 12, 'Feb' => 27, 'Mar' => 18])
+    ->addSeries(Series::of('Costs', ['Jan' => 6, 'Feb' => 14, 'Mar' => 9]))
+    ->legend();
+```
+
+Available on line and bar charts. Each legend entry is a `<label>` bound
+to a hidden checkbox; clicking it hides that series and dims the entry.
+Pure CSS — no JavaScript.
+
+Caveats:
+
+- **State is page-local.** Refreshing the page resets every toggle; without
+  JS there is nowhere to persist it.
+- **Axes do not rescale.** Hiding a tall series leaves the value axis at
+  the original combined min/max, so the remaining series stay at their
+  original positions on the canvas.
+- **Multiple charts on the same page** get unique IDs automatically, so
+  toggling one chart never affects another.
+- **Keyboard-accessible.** The `<label>` + checkbox combo is natively
+  focusable; pressing Space toggles the series.
+
 ## Animations
 
 ```php

--- a/src/Charts/BarChart.php
+++ b/src/Charts/BarChart.php
@@ -27,6 +27,7 @@ class BarChart extends AbstractChart
     protected float $cornerRadius = 0.0;
     protected bool $showAxes = false;
     protected bool $showGrid = false;
+    protected bool $showLegend = false;
     protected int $tickCount = 5;
     protected bool $useColorPerBar = false;
 
@@ -112,6 +113,19 @@ class BarChart extends AbstractChart
     public function ticks(int $count): static
     {
         $this->tickCount = max(2, $count);
+        return $this;
+    }
+
+    /**
+     * Render a CSS-only toggle legend below the chart. Each entry is a
+     * `<label>` bound to a hidden checkbox; clicking an entry hides its
+     * series and dims the entry. State is page-local (no JS = no
+     * persistence) and the value axis does not rescale to the remaining
+     * series.
+     */
+    public function legend(bool $on = true): static
+    {
+        $this->showLegend = $on;
         return $this;
     }
 
@@ -261,6 +275,10 @@ class BarChart extends AbstractChart
                     verticalAlign: 'bottom',
                 ));
             }
+        }
+
+        if ($this->showLegend) {
+            $wrapper->setLegend($this->buildLegendEntries());
         }
 
         return $wrapper->render();
@@ -505,6 +523,10 @@ class BarChart extends AbstractChart
             }
         }
 
+        if ($this->showLegend) {
+            $wrapper->setLegend($this->buildLegendEntries());
+        }
+
         return $wrapper->render();
     }
 
@@ -654,6 +676,25 @@ class BarChart extends AbstractChart
             leftPct: ($left + $width) / $viewport->width * 100,
             topPct: ($y + $height / 2) / $viewport->height * 100,
         ));
+    }
+
+    /**
+     * @return list<array{id: string, seriesIndex: int, name: string, color: string}>
+     */
+    private function buildLegendEntries(): array
+    {
+        $chartId = $this->chartId();
+        $entries = [];
+        foreach ($this->seriesCollection->items as $i => $series) {
+            $name = $series->name !== '' ? $series->name : 'Series ' . ($i + 1);
+            $entries[] = [
+                'id' => "{$chartId}-s{$i}",
+                'seriesIndex' => $i,
+                'name' => $name,
+                'color' => $this->resolveSeriesColor($series, $i),
+            ];
+        }
+        return $entries;
     }
 
     /**

--- a/src/Charts/LineChart.php
+++ b/src/Charts/LineChart.php
@@ -30,6 +30,7 @@ class LineChart extends AbstractChart
     protected bool $showGrid = false;
     protected bool $showPoints = false;
     protected bool $showCrosshair = false;
+    protected bool $showLegend = false;
 
     protected int $tickCount = 5;
 
@@ -131,6 +132,18 @@ class LineChart extends AbstractChart
         return $this;
     }
 
+    /**
+     * Render a CSS-only toggle legend below the chart. Each entry is a
+     * `<label>` bound to a hidden checkbox; clicking an entry hides its
+     * series and dims the entry. State is page-local (no JS = no
+     * persistence) and the Y axis does not rescale to the remaining series.
+     */
+    public function legend(bool $on = true): static
+    {
+        $this->showLegend = $on;
+        return $this;
+    }
+
     public function render(): string
     {
         if ($this->seriesCollection->isEmpty()) {
@@ -205,7 +218,30 @@ class LineChart extends AbstractChart
             $this->addLabels($wrapper, $xScale, $yScale);
         }
 
+        if ($this->showLegend) {
+            $wrapper->setLegend($this->buildLegendEntries());
+        }
+
         return $wrapper->render();
+    }
+
+    /**
+     * @return list<array{id: string, seriesIndex: int, name: string, color: string}>
+     */
+    private function buildLegendEntries(): array
+    {
+        $chartId = $this->chartId();
+        $entries = [];
+        foreach ($this->seriesCollection->items as $i => $series) {
+            $name = $series->name !== '' ? $series->name : 'Series ' . ($i + 1);
+            $entries[] = [
+                'id' => "{$chartId}-s{$i}",
+                'seriesIndex' => $i,
+                'name' => $name,
+                'color' => $this->resolveColor($series, $i),
+            ];
+        }
+        return $entries;
     }
 
     private function renderSeries(

--- a/src/Svg/Wrapper.php
+++ b/src/Svg/Wrapper.php
@@ -29,6 +29,9 @@ final class Wrapper
     /** @var list<Tooltip> */
     private array $tooltips = [];
 
+    /** @var list<array{id: string, seriesIndex: int, name: string, color: string}> */
+    private array $legendEntries = [];
+
     private ?string $userClass = null;
 
     private bool $hasSeriesElements = false;
@@ -103,6 +106,21 @@ final class Wrapper
         return $this;
     }
 
+    /**
+     * Enable a CSS-only toggle legend. Each entry produces a hidden
+     * checkbox + label; the wrapper emits CSS rules that hide the matching
+     * `series-{N}` elements when the entry is unchecked.
+     *
+     * @param list<array{id: string, seriesIndex: int, name: string, color: string}> $entries
+     *   `id` must be a CSS-safe identifier unique to the chart instance
+     *   (the chart layer is responsible for collision avoidance).
+     */
+    public function setLegend(array $entries): self
+    {
+        $this->legendEntries = $entries;
+        return $this;
+    }
+
     public function render(): string
     {
         $paddingBottom = (1.0 / max($this->aspectRatio, 0.01)) * 100.0;
@@ -115,10 +133,16 @@ final class Wrapper
             $classes[] = $this->userClass;
         }
 
-        $wrapperStyle = sprintf(
+        $hasLegend = $this->legendEntries !== [];
+
+        // Aspect-ratio styling sits on whichever element holds the SVG: the
+        // outer .svgraph when no legend, or an inner .svgraph__chart when a
+        // legend is rendered (so the legend can sit below in flow).
+        $aspectStyle = sprintf(
             'position:relative;width:100%%;padding-bottom:%s%%;',
             Tag::formatFloat($paddingBottom),
         );
+        $wrapperStyle = $hasLegend ? '' : $aspectStyle;
 
         if ($this->tooltips !== []) {
             $bg = Css::color($this->theme->tooltipBackground) ?? '#1f2937';
@@ -165,11 +189,30 @@ final class Wrapper
             'style' => $wrapperStyle,
         ]);
 
-        if ($this->tooltips !== [] || $this->hasSeriesElements || $this->animated || $this->crosshairColumns > 0) {
+        if ($this->tooltips !== [] || $this->hasSeriesElements || $this->animated || $this->crosshairColumns > 0 || $hasLegend) {
             $div->appendRaw($this->buildStyle());
         }
 
-        $div->append($svg);
+        // Hidden checkbox toggles must precede the chart and legend so the
+        // sibling combinator (~) can target them when unchecked.
+        if ($hasLegend) {
+            foreach ($this->legendEntries as $entry) {
+                $div->append(Tag::void('input', [
+                    'type' => 'checkbox',
+                    'id' => $entry['id'],
+                    'class' => 'svgraph-toggle',
+                    'checked' => true,
+                    'aria-label' => $entry['name'],
+                ]));
+            }
+        }
+
+        // The chart parent: outer .svgraph when no legend, inner .svgraph__chart when legend is on.
+        $chartParent = $hasLegend
+            ? Tag::make('div', ['class' => 'svgraph__chart', 'style' => $aspectStyle])
+            : $div;
+
+        $chartParent->append($svg);
 
         if ($this->labels !== []) {
             $fontFamily = Css::fontFamily($this->theme->fontFamily) ?? 'inherit';
@@ -188,7 +231,7 @@ final class Wrapper
             foreach ($this->labels as $label) {
                 $labelTag->appendRaw($label->render());
             }
-            $div->append($labelTag);
+            $chartParent->append($labelTag);
         }
 
         foreach ($this->tooltips as $tip) {
@@ -200,10 +243,33 @@ final class Wrapper
                 'data-x' => $tip->dataX !== null ? (string) $tip->dataX : null,
                 'style' => "position:absolute;left:{$left};top:{$top};",
             ];
-            $div->append(Tag::make('div', $attrs)->appendRaw($tip->text));
+            $chartParent->append(Tag::make('div', $attrs)->appendRaw($tip->text));
+        }
+
+        if ($hasLegend) {
+            $div->append($chartParent);
+            $div->append($this->buildLegend());
         }
 
         return (string) $div;
+    }
+
+    private function buildLegend(): Tag
+    {
+        $legend = Tag::make('div', ['class' => 'svgraph-legend']);
+        foreach ($this->legendEntries as $entry) {
+            $swatchColor = Css::color($entry['color']) ?? 'currentColor';
+            $label = Tag::make('label', [
+                'for' => $entry['id'],
+                'class' => 'svgraph-legend__entry',
+            ]);
+            $label->appendRaw(
+                '<span class="svgraph-legend__swatch" style="background:' . $swatchColor . ';"></span>',
+            );
+            $label->append($entry['name']);
+            $legend->append($label);
+        }
+        return $legend;
     }
 
     private function buildStyle(): string
@@ -226,7 +292,50 @@ final class Wrapper
             $css .= $this->buildCrosshairStyle();
         }
 
+        if ($this->legendEntries !== []) {
+            $css .= $this->buildLegendStyle();
+        }
+
         return "<style>{$css}</style>";
+    }
+
+    /**
+     * Pure-CSS toggle legend: each hidden checkbox sits as a sibling of the
+     * chart parent and the legend container, so :not(:checked) ~ rules can
+     * hide the matching `series-{N}` elements and dim the legend entry.
+     *
+     * State is page-local — refreshing the page resets every toggle. Hiding
+     * a series does NOT rescale the chart's axes; the remaining series stay
+     * at their original positions.
+     */
+    private function buildLegendStyle(): string
+    {
+        $fontFamily = Css::fontFamily($this->theme->fontFamily) ?? 'inherit';
+        $fontSize = Css::length($this->theme->fontSize) ?? '0.75rem';
+        $textColor = Css::color($this->theme->textColor) ?? 'currentColor';
+
+        // Visually-hidden checkbox (still keyboard-focusable via the matched <label>).
+        $base = '.svgraph-toggle{position:absolute;width:1px;height:1px;padding:0;margin:-1px;'
+            . 'overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0;}'
+            . ".svgraph-legend{display:flex;flex-wrap:wrap;gap:0.4em 1em;margin-top:0.5em;"
+            . "font-family:{$fontFamily};font-size:{$fontSize};color:{$textColor};line-height:1.2;}"
+            . '.svgraph-legend__entry{display:inline-flex;align-items:center;gap:0.4em;'
+            . 'cursor:pointer;user-select:none;transition:opacity 0.15s;}'
+            . '.svgraph-legend__swatch{display:inline-block;width:0.8em;height:0.8em;'
+            . 'border-radius:0.15em;flex:none;}';
+
+        $rules = '';
+        foreach ($this->legendEntries as $entry) {
+            $id = $entry['id'];
+            $n = $entry['seriesIndex'];
+            // id is built from chartId() (svgraph-{int}) + s{int}; only [a-zA-Z0-9-].
+            $rules .= "#{$id}:not(:checked)~.svgraph__chart .series-{$n}{display:none;}"
+                . "#{$id}:not(:checked)~.svgraph-legend label[for=\"{$id}\"]{opacity:0.4;}"
+                . "#{$id}:focus-visible~.svgraph-legend label[for=\"{$id}\"]{"
+                . 'outline:2px solid currentColor;outline-offset:2px;}';
+        }
+
+        return $base . $rules;
     }
 
     private function buildHoverStyle(): string

--- a/tests/Charts/LegendTest.php
+++ b/tests/Charts/LegendTest.php
@@ -1,0 +1,314 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Noeka\Svgraph\Tests\Charts;
+
+use Noeka\Svgraph\Chart;
+use Noeka\Svgraph\Data\Series;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Coverage for the CSS-only toggle legend (issue #10).
+ *
+ * The legend is built from a hidden checkbox per series and a `<label>` per
+ * series; CSS rules in the chart's <style> block hide `series-{N}` elements
+ * when the matching checkbox is unchecked, with no JavaScript involved.
+ */
+final class LegendTest extends TestCase
+{
+    // ── Markup structure ──────────────────────────────────────────────────────
+
+    public function test_line_legend_renders_one_input_and_label_per_series(): void
+    {
+        $svg = Chart::line(['Mon' => 10, 'Tue' => 20])
+            ->addSeries(Series::of('Costs', ['Mon' => 5, 'Tue' => 8]))
+            ->legend()
+            ->render();
+
+        // Two checkboxes — one per series — both checked by default.
+        self::assertSame(2, substr_count($svg, '<input '));
+        self::assertSame(2, substr_count($svg, 'class="svgraph-toggle"'));
+        self::assertSame(2, substr_count($svg, ' checked'));
+        // Two <label> entries.
+        self::assertSame(2, substr_count($svg, '<label '));
+        self::assertStringContainsString('class="svgraph-legend"', $svg);
+    }
+
+    public function test_line_legend_uses_series_name_when_present(): void
+    {
+        $svg = Chart::line([1, 2, 3])
+            ->addSeries(Series::of('Costs', [4, 5, 6]))
+            ->legend()
+            ->render();
+
+        // First series has no name → fallback "Series 1"; second has "Costs".
+        self::assertStringContainsString('Series 1', $svg);
+        self::assertStringContainsString('Costs', $svg);
+    }
+
+    public function test_line_legend_label_for_matches_input_id(): void
+    {
+        $svg = Chart::line([1, 2])
+            ->addSeries(Series::of('B', [3, 4]))
+            ->legend()
+            ->render();
+
+        // Each label's `for` references its checkbox `id` — required by the
+        // checkbox-trick toggle pattern.
+        self::assertMatchesRegularExpression(
+            '/<input[^>]*id="(svgraph-\d+-s0)"[^>]*>.*<label[^>]*for="\1"/s',
+            $svg,
+        );
+        self::assertMatchesRegularExpression(
+            '/<input[^>]*id="(svgraph-\d+-s1)"[^>]*>.*<label[^>]*for="\1"/s',
+            $svg,
+        );
+    }
+
+    public function test_legend_input_id_collisions_avoided_across_charts(): void
+    {
+        $a = Chart::line([1, 2])->addSeries(Series::of('B', [3, 4]))->legend()->render();
+        $b = Chart::line([1, 2])->addSeries(Series::of('B', [3, 4]))->legend()->render();
+
+        $extractId = static function (string $svg): string {
+            if (preg_match('/id="(svgraph-\d+)-s0"/', $svg, $match) !== 1) {
+                self::fail('No svgraph chart ID found in legend markup.');
+            }
+            return $match[1];
+        };
+        self::assertNotSame($extractId($a), $extractId($b));
+    }
+
+    public function test_legend_swatch_uses_resolved_series_color(): void
+    {
+        $svg = Chart::line([1, 2])
+            ->addSeries(Series::of('Two', [3, 4], '#ff00ff'))
+            ->legend()
+            ->render();
+
+        // Default palette colour for series 0 plus the explicit colour for series 1.
+        self::assertStringContainsString('background:#3b82f6', $svg);
+        self::assertStringContainsString('background:#ff00ff', $svg);
+    }
+
+    public function test_legend_aria_label_set_to_series_name(): void
+    {
+        $svg = Chart::line([1, 2])
+            ->addSeries(Series::of('Visits', [3, 4]))
+            ->legend()
+            ->render();
+
+        // Hidden checkbox needs an accessible name; we use the series name.
+        self::assertStringContainsString('aria-label="Visits"', $svg);
+    }
+
+    // ── Toggle CSS rules ──────────────────────────────────────────────────────
+
+    public function test_legend_emits_unchecked_hide_rule_per_series(): void
+    {
+        $svg = Chart::line([1, 2])
+            ->addSeries(Series::of('B', [3, 4]))
+            ->legend()
+            ->render();
+
+        // Each series gets a `:not(:checked) ~ .svgraph__chart .series-N { display:none }` rule.
+        self::assertMatchesRegularExpression(
+            '/#svgraph-\d+-s0:not\(:checked\)~\.svgraph__chart \.series-0\{display:none;\}/',
+            $svg,
+        );
+        self::assertMatchesRegularExpression(
+            '/#svgraph-\d+-s1:not\(:checked\)~\.svgraph__chart \.series-1\{display:none;\}/',
+            $svg,
+        );
+    }
+
+    public function test_legend_emits_unchecked_dim_rule_per_series(): void
+    {
+        $svg = Chart::line([1, 2])
+            ->addSeries(Series::of('B', [3, 4]))
+            ->legend()
+            ->render();
+
+        // Unchecked entries are dimmed via opacity.
+        self::assertMatchesRegularExpression(
+            '/#svgraph-\d+-s0:not\(:checked\)~\.svgraph-legend label\[for="svgraph-\d+-s0"\]\{opacity:0\.4;\}/',
+            $svg,
+        );
+    }
+
+    public function test_legend_emits_focus_visible_outline_for_keyboard_users(): void
+    {
+        $svg = Chart::line([1, 2])
+            ->addSeries(Series::of('B', [3, 4]))
+            ->legend()
+            ->render();
+
+        // Keyboard focus on the hidden input must surface visually on its label.
+        self::assertMatchesRegularExpression(
+            '/#svgraph-\d+-s0:focus-visible~\.svgraph-legend label\[for="svgraph-\d+-s0"\]\{outline:2px/',
+            $svg,
+        );
+    }
+
+    public function test_legend_visually_hides_checkbox(): void
+    {
+        $svg = Chart::line([1, 2])->legend()->render();
+
+        // Visually-hidden pattern keeps the checkbox keyboard-accessible.
+        self::assertStringContainsString('.svgraph-toggle{position:absolute;width:1px;height:1px;', $svg);
+    }
+
+    // ── Wrapper restructuring ────────────────────────────────────────────────
+
+    public function test_legend_introduces_inner_chart_wrapper(): void
+    {
+        // Without legend the SVG sits directly inside .svgraph; with legend
+        // it nests inside .svgraph__chart so the legend can flow below.
+        $without = Chart::line([1, 2, 3])->render();
+        $with = Chart::line([1, 2, 3])->legend()->render();
+
+        self::assertStringNotContainsString('svgraph__chart', $without);
+        self::assertStringContainsString('class="svgraph__chart"', $with);
+        self::assertStringContainsString('padding-bottom:', $with);
+    }
+
+    public function test_no_legend_keeps_outer_padding_bottom(): void
+    {
+        // Backward compat: when legend is off, the .svgraph div itself
+        // still carries padding-bottom for the responsive wrapper.
+        $svg = Chart::line([1, 2, 3])->aspect(2.0)->render();
+        self::assertMatchesRegularExpression(
+            '/<div class="svgraph[^"]*" style="position:relative;width:100%;padding-bottom:50%/',
+            $svg,
+        );
+    }
+
+    public function test_legend_off_by_default(): void
+    {
+        $svg = Chart::line([1, 2, 3])
+            ->addSeries(Series::of('B', [4, 5, 6]))
+            ->render();
+
+        self::assertStringNotContainsString('svgraph-legend', $svg);
+        self::assertStringNotContainsString('svgraph-toggle', $svg);
+        self::assertStringNotContainsString('<input ', $svg);
+    }
+
+    public function test_legend_can_be_disabled_explicitly(): void
+    {
+        $svg = Chart::line([1, 2])->legend(true)->legend(false)->render();
+        self::assertStringNotContainsString('svgraph-legend', $svg);
+    }
+
+    // ── Single-series ─────────────────────────────────────────────────────────
+
+    public function test_legend_works_with_single_series(): void
+    {
+        $svg = Chart::line(['Mon' => 10, 'Tue' => 20])->legend()->render();
+
+        self::assertSame(1, substr_count($svg, '<input '));
+        self::assertSame(1, substr_count($svg, '<label '));
+    }
+
+    // ── BarChart integration ──────────────────────────────────────────────────
+
+    public function test_bar_legend_renders_per_series(): void
+    {
+        $svg = Chart::bar(['Q1' => 10, 'Q2' => 20])
+            ->addSeries(Series::of('Costs', ['Q1' => 5, 'Q2' => 8]))
+            ->legend()
+            ->render();
+
+        self::assertSame(2, substr_count($svg, 'class="svgraph-toggle"'));
+        self::assertStringContainsString('Series 1', $svg);
+        self::assertStringContainsString('Costs', $svg);
+    }
+
+    public function test_bar_legend_works_horizontal(): void
+    {
+        $svg = Chart::bar(['A' => 1, 'B' => 2])
+            ->addSeries(Series::of('Two', ['A' => 3, 'B' => 4]))
+            ->horizontal()
+            ->legend()
+            ->render();
+
+        self::assertSame(2, substr_count($svg, 'class="svgraph-toggle"'));
+        self::assertStringContainsString('class="svgraph-legend"', $svg);
+    }
+
+    public function test_bar_legend_stacked_targets_per_series_classes(): void
+    {
+        $svg = Chart::bar(['Q1' => 10])
+            ->addSeries(Series::of('Costs', ['Q1' => 5]))
+            ->stacked()
+            ->legend()
+            ->render();
+
+        // Toggle rules must target the same `.series-N` classes the bars use.
+        self::assertMatchesRegularExpression(
+            '/:not\(:checked\)~\.svgraph__chart \.series-0\{display:none;\}/',
+            $svg,
+        );
+        self::assertMatchesRegularExpression(
+            '/:not\(:checked\)~\.svgraph__chart \.series-1\{display:none;\}/',
+            $svg,
+        );
+    }
+
+    // ── Output-safety ─────────────────────────────────────────────────────────
+
+    public function test_legend_escapes_series_name(): void
+    {
+        $svg = Chart::line([1, 2])
+            ->addSeries(Series::of('<script>x</script>', [3, 4]))
+            ->legend()
+            ->render();
+
+        self::assertStringNotContainsString('<script>x</script>', $svg);
+        self::assertStringContainsString('&lt;script&gt;x&lt;/script&gt;', $svg);
+    }
+
+    public function test_legend_swatch_falls_back_when_color_invalid(): void
+    {
+        $svg = Chart::line([1, 2])
+            ->addSeries(Series::of('Bad', [3, 4], 'red;background:url(x)'))
+            ->legend()
+            ->render();
+
+        // Regression: the swatch interpolates the colour into a CSS `style`
+        // attribute. Css::color must reject the injection so the swatch
+        // falls back to a safe value rather than leaking `url(x)` into CSS.
+        self::assertStringContainsString('<span class="svgraph-legend__swatch" style="background:currentColor;"', $svg);
+        self::assertStringNotContainsString('background:red;background:url(x)', $svg);
+    }
+
+    // ── Co-existence with other features ──────────────────────────────────────
+
+    public function test_legend_with_animation_renders_both(): void
+    {
+        $svg = Chart::line([1, 2, 3])
+            ->addSeries(Series::of('B', [4, 5, 6]))
+            ->animate()
+            ->legend()
+            ->render();
+
+        self::assertStringContainsString('svgraph-line-path', $svg);
+        self::assertStringContainsString('class="svgraph-legend"', $svg);
+    }
+
+    public function test_legend_with_axes_and_grid(): void
+    {
+        $svg = Chart::line(['Mon' => 1, 'Tue' => 2, 'Wed' => 3])
+            ->addSeries(Series::of('B', ['Mon' => 4, 'Tue' => 5, 'Wed' => 6]))
+            ->axes()
+            ->grid()
+            ->legend()
+            ->render();
+
+        // Axis labels still render inside the inner chart wrapper.
+        self::assertStringContainsString('svgraph__chart', $svg);
+        self::assertStringContainsString('svgraph__labels', $svg);
+        self::assertStringContainsString('svgraph-legend', $svg);
+    }
+}


### PR DESCRIPTION
Each series gets a hidden checkbox + <label> swatch entry; CSS rules
hide the matching `series-{N}` elements when the entry is unchecked
and dim the label, with no JavaScript involved. Multiple charts on a
page get unique IDs so toggles never collide.